### PR TITLE
callback-based retryImageAction + Don't ignore errors reported during Docker push/pull

### DIFF
--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -62,25 +61,12 @@ type DockerClient interface {
 	TagImage(name string, opts docker.TagImageOptions) error
 }
 
-func retryImageAction(opts interface{}, action func() error) error {
+func retryImageAction(actionName string, action func() error) error {
 	var err error
 	var retriableError = false
-	var actionName string
-
-	pullOpt := docker.PullImageOptions{}
-	pushOpt := docker.PushImageOptions{}
 
 	for retries := 0; retries <= DefaultPushOrPullRetryCount; retries++ {
-		if reflect.TypeOf(opts) == reflect.TypeOf(pullOpt) {
-			actionName = "Pull"
-			err = action()
-		} else if reflect.TypeOf(opts) == reflect.TypeOf(pushOpt) {
-			actionName = "Push"
-			err = action()
-		} else {
-			return errors.New("not match Pull or Push action")
-		}
-
+		err = action()
 		if err == nil {
 			return nil
 		}
@@ -135,7 +121,7 @@ func dockerPullImage(client DockerClient, name string, authConfig docker.AuthCon
 		opts.OutputStream = os.Stderr
 		opts.RawJSONStream = false
 	}
-	return retryImageAction(opts, func() error {
+	return retryImageAction("Pull", func() error {
 		return client.PullImage(opts, authConfig)
 	})
 }
@@ -169,7 +155,7 @@ func dockerPushImage(client DockerClient, name string, authConfig docker.AuthCon
 		RawJSONStream: true,
 	}
 
-	if err := retryImageAction(opts, func() error {
+	if err := retryImageAction("Push", func() error {
 		return client.PushImage(opts, authConfig)
 	}); err != nil {
 		return "", err

--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -62,7 +62,7 @@ type DockerClient interface {
 	TagImage(name string, opts docker.TagImageOptions) error
 }
 
-func RetryImageAction(client DockerClient, opts interface{}, authConfig docker.AuthConfiguration) error {
+func retryImageAction(opts interface{}, action func() error) error {
 	var err error
 	var retriableError = false
 	var actionName string
@@ -73,10 +73,10 @@ func RetryImageAction(client DockerClient, opts interface{}, authConfig docker.A
 	for retries := 0; retries <= DefaultPushOrPullRetryCount; retries++ {
 		if reflect.TypeOf(opts) == reflect.TypeOf(pullOpt) {
 			actionName = "Pull"
-			err = client.PullImage(opts.(docker.PullImageOptions), authConfig)
+			err = action()
 		} else if reflect.TypeOf(opts) == reflect.TypeOf(pushOpt) {
 			actionName = "Push"
-			err = client.PushImage(opts.(docker.PushImageOptions), authConfig)
+			err = action()
 		} else {
 			return errors.New("not match Pull or Push action")
 		}
@@ -135,7 +135,9 @@ func dockerPullImage(client DockerClient, name string, authConfig docker.AuthCon
 		opts.OutputStream = os.Stderr
 		opts.RawJSONStream = false
 	}
-	return RetryImageAction(client, opts, authConfig)
+	return retryImageAction(opts, func() error {
+		return client.PullImage(opts, authConfig)
+	})
 }
 
 // dockerPushImage pushes a docker image to the registry specified in its tag.
@@ -167,7 +169,9 @@ func dockerPushImage(client DockerClient, name string, authConfig docker.AuthCon
 		RawJSONStream: true,
 	}
 
-	if err := RetryImageAction(client, opts, authConfig); err != nil {
+	if err := retryImageAction(opts, func() error {
+		return client.PushImage(opts, authConfig)
+	}); err != nil {
 		return "", err
 	}
 	return digestWriter.Digest, nil

--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -112,10 +112,12 @@ func dockerPullImage(client DockerClient, name string, authConfig docker.AuthCon
 
 	glog.V(4).Infof("pulling image %q with ref %#v as repository: %s and tag: %s", name, ref, ref.Exact(), tag)
 	return retryImageAction("Pull", func() error {
+		progressWriter := imageprogress.NewPullWriter(logProgress)
+		defer progressWriter.Close()
 		opts := docker.PullImageOptions{
 			Repository:    ref.Exact(),
 			Tag:           tag,
-			OutputStream:  imageprogress.NewPullWriter(logProgress),
+			OutputStream:  progressWriter,
 			RawJSONStream: true,
 		}
 		if glog.Is(5) {
@@ -146,7 +148,9 @@ func dockerPushImage(client DockerClient, name string, authConfig docker.AuthCon
 			logProgress := func(s string) {
 				glog.V(0).Infof("%s", s)
 			}
-			progressWriter = imageprogress.NewPushWriter(logProgress)
+			pw := imageprogress.NewPushWriter(logProgress)
+			defer pw.Close()
+			progressWriter = pw
 		}
 		digestWriter = newDigestWriter()
 

--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -111,17 +111,17 @@ func dockerPullImage(client DockerClient, name string, authConfig docker.AuthCon
 	ref.ID = ""
 
 	glog.V(4).Infof("pulling image %q with ref %#v as repository: %s and tag: %s", name, ref, ref.Exact(), tag)
-	opts := docker.PullImageOptions{
-		Repository:    ref.Exact(),
-		Tag:           tag,
-		OutputStream:  imageprogress.NewPullWriter(logProgress),
-		RawJSONStream: true,
-	}
-	if glog.Is(5) {
-		opts.OutputStream = os.Stderr
-		opts.RawJSONStream = false
-	}
 	return retryImageAction("Pull", func() error {
+		opts := docker.PullImageOptions{
+			Repository:    ref.Exact(),
+			Tag:           tag,
+			OutputStream:  imageprogress.NewPullWriter(logProgress),
+			RawJSONStream: true,
+		}
+		if glog.Is(5) {
+			opts.OutputStream = os.Stderr
+			opts.RawJSONStream = false
+		}
 		return client.PullImage(opts, authConfig)
 	})
 }
@@ -137,25 +137,26 @@ func dockerPullImage(client DockerClient, name string, authConfig docker.AuthCon
 func dockerPushImage(client DockerClient, name string, authConfig docker.AuthConfiguration) (string, error) {
 	repository, tag := docker.ParseRepositoryTag(name)
 
-	var progressWriter io.Writer
-	if glog.Is(5) {
-		progressWriter = newSimpleWriter(os.Stderr)
-	} else {
-		logProgress := func(s string) {
-			glog.V(0).Infof("%s", s)
-		}
-		progressWriter = imageprogress.NewPushWriter(logProgress)
-	}
-	digestWriter := newDigestWriter()
-
-	opts := docker.PushImageOptions{
-		Name:          repository,
-		Tag:           tag,
-		OutputStream:  io.MultiWriter(progressWriter, digestWriter),
-		RawJSONStream: true,
-	}
-
+	var digestWriter *digestWriter
 	if err := retryImageAction("Push", func() error {
+		var progressWriter io.Writer
+		if glog.Is(5) {
+			progressWriter = newSimpleWriter(os.Stderr)
+		} else {
+			logProgress := func(s string) {
+				glog.V(0).Infof("%s", s)
+			}
+			progressWriter = imageprogress.NewPushWriter(logProgress)
+		}
+		digestWriter = newDigestWriter()
+
+		opts := docker.PushImageOptions{
+			Name:          repository,
+			Tag:           tag,
+			OutputStream:  io.MultiWriter(progressWriter, digestWriter),
+			RawJSONStream: true,
+		}
+
 		return client.PushImage(opts, authConfig)
 	}); err != nil {
 		return "", err

--- a/pkg/build/builder/dockerutil_test.go
+++ b/pkg/build/builder/dockerutil_test.go
@@ -51,6 +51,9 @@ func fakePushImageFunc(opts docker.PushImageOptions, auth docker.AuthConfigurati
 		return errors.New(RetriableErrors[0])
 	case "tag_test_err_no_exist_foo_bar":
 		return errors.New("no_exist_err_foo_bar")
+	case "tag_test_err_no_exist_progress_only":
+		_, _ = opts.OutputStream.Write([]byte(`{"error":"no_exist_progress_only"}`)) // Ignore error even if returned from the progressWriter, test that progressWriter.Close is used.
+		return nil                                                                   // Don't fail the PushImage either, we want to ensure the progres parser detects this
 	}
 	return nil
 }
@@ -64,6 +67,9 @@ func fakePullImageFunc(opts docker.PullImageOptions, auth docker.AuthConfigurati
 		return errors.New(RetriableErrors[0])
 	case "repo_test_err_no_exist_foo_bar":
 		return errors.New("no_exist_err_foo_bar")
+	case "repo_test_err_no_exist_progress_only":
+		_, _ = opts.OutputStream.Write([]byte(`{"error":"no_exist_progress_only"}`)) // Ignore error even if returned from the progressWriter, test that progressWriter.Close is used.
+		return nil                                                                   // Don't fail the PullImage either, we want to ensure the progres parser detects this
 	}
 	return nil
 }
@@ -199,6 +205,12 @@ func TestPushImage(t *testing.T) {
 		t.Errorf("Unexpect push image : %v, want error", err)
 	}
 	defer func() { fooBarRunTimes = 0 }()
+
+	//expect fail
+	testImageName = "repo_foo_bar:tag_test_err_no_exist_progress_only"
+	if _, err := dockerPushImage(fakeDocker, testImageName, testAuth); err == nil {
+		t.Errorf("Unexpect push image : %v, want error", err)
+	}
 }
 
 func TestPullImage(t *testing.T) {
@@ -245,6 +257,12 @@ func TestPullImage(t *testing.T) {
 		t.Errorf("Unexpect pull image : %v, want error", err)
 	}
 	defer func() { fooBarRunTimes = 0 }()
+
+	//expect fail
+	testImageName = "repo_test_err_no_exist_progress_only"
+	if err := dockerPullImage(fakeDocker, testImageName, testAuth); err == nil {
+		t.Errorf("Unexpect pull image : %v, want error", err)
+	}
 }
 
 func TestGetContainerNameOrID(t *testing.T) {


### PR DESCRIPTION
Per conversation in https://github.com/openshift/origin/pull/20941, this:

- Modifies `RetryImageAction`→`retryImageAction` to use a callback instead of containing parts of the calling functions and using reflection to choose which part to call. This could reportedly be useful for the `buildah`-based implementation as well.

- Fixes `dockerPushImage`/`dockerPullImage` to correctly detect errors reported through the `imageprogress` channel. These functions don’t have any callers outside of tests anymore, so this is not really interesting — but this preserves the bug fixes in case they were revived, and I needed to updated them for the `retryImageAction` changes to build anyway.

Manually tested only using `go test ./...`; hoping the CI can handle the bigger picture.