### PR TITLE
Retry pulling or pushing images again, for certain errors

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
 	docker "github.com/fsouza/go-dockerclient"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 
@@ -488,7 +489,11 @@ func (d *DaemonlessClient) BuildImage(opts docker.BuildImageOptions) error {
 func (d *DaemonlessClient) PushImage(opts docker.PushImageOptions, auth docker.AuthConfiguration) error {
 	imageName := opts.Name
 	if opts.Tag != "" {
-		imageName = imageName + ":" + opts.Tag
+		if _, err := digest.Parse(opts.Tag); err == nil {
+			imageName = imageName + "@" + opts.Tag
+		} else {
+			imageName = imageName + ":" + opts.Tag
+		}
 	}
 	return pushDaemonlessImage(d.SystemContext, d.Store, imageName, auth)
 }
@@ -551,7 +556,11 @@ func (d *DaemonlessClient) RemoveContainer(opts docker.RemoveContainerOptions) e
 func (d *DaemonlessClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
 	imageName := opts.Repository
 	if opts.Tag != "" {
-		imageName = imageName + ":" + opts.Tag
+		if _, err := digest.Parse(opts.Tag); err == nil {
+			imageName = imageName + "@" + opts.Tag
+		} else {
+			imageName = imageName + ":" + opts.Tag
+		}
 	}
 	return pullDaemonlessImage(d.SystemContext, d.Store, imageName, auth)
 }
@@ -559,7 +568,11 @@ func (d *DaemonlessClient) PullImage(opts docker.PullImageOptions, auth docker.A
 func (d *DaemonlessClient) TagImage(name string, opts docker.TagImageOptions) error {
 	imageName := opts.Repo
 	if opts.Tag != "" {
-		imageName = imageName + ":" + opts.Tag
+		if _, err := digest.Parse(opts.Tag); err == nil {
+			imageName = imageName + "@" + opts.Tag
+		} else {
+			imageName = imageName + ":" + opts.Tag
+		}
 	}
 	return tagDaemonlessImage(d.SystemContext, d.Store, name, imageName)
 }

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -184,27 +184,11 @@ func (d *DockerBuilder) Build() error {
 }
 
 func (d *DockerBuilder) pullImage(name string, authConfig docker.AuthConfiguration) error {
-	repository, tag := docker.ParseRepositoryTag(name)
-	options := docker.PullImageOptions{
-		Repository: repository,
-		Tag:        tag,
-	}
-
-	if options.Tag == "" && strings.Contains(name, "@") {
-		options.Repository = name
-	}
-
-	return d.dockerClient.PullImage(options, authConfig)
+	return dockerPullImage(d.dockerClient, name, authConfig)
 }
 
 func (d *DockerBuilder) pushImage(name string, authConfig docker.AuthConfiguration) (string, error) {
-	repository, tag := docker.ParseRepositoryTag(name)
-	options := docker.PushImageOptions{
-		Name: repository,
-		Tag:  tag,
-	}
-	err := d.dockerClient.PushImage(options, authConfig)
-	return "", err
+	return dockerPushImage(d.dockerClient, name, authConfig)
 }
 
 // copyConfigMaps copies all files from the directory where the configMap is

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	dockerclient "github.com/fsouza/go-dockerclient"
@@ -445,17 +444,7 @@ func (s *S2IBuilder) setupPullSecret() (*dockerclient.AuthConfigurations, error)
 
 func (s *S2IBuilder) pullImage(name string, authConfig dockerclient.AuthConfiguration) error {
 	glog.V(2).Infof("Explicitly pulling image %s", name)
-	repository, tag := dockerclient.ParseRepositoryTag(name)
-	options := dockerclient.PullImageOptions{
-		Repository: repository,
-		Tag:        tag,
-	}
-
-	if options.Tag == "" && strings.Contains(name, "@") {
-		options.Repository = name
-	}
-
-	return s.dockerClient.PullImage(options, authConfig)
+	return dockerPullImage(s.dockerClient, name, authConfig)
 }
 
 func (s *S2IBuilder) buildImage(contextdir string, optimization buildapiv1.ImageOptimizationPolicy, opts *dockerclient.BuildImageOptions) error {
@@ -472,13 +461,7 @@ func (s *S2IBuilder) buildImage(contextdir string, optimization buildapiv1.Image
 }
 
 func (s *S2IBuilder) pushImage(name string, authConfig dockerclient.AuthConfiguration) (string, error) {
-	repository, tag := dockerclient.ParseRepositoryTag(name)
-	options := dockerclient.PushImageOptions{
-		Name: repository,
-		Tag:  tag,
-	}
-	err := s.dockerClient.PushImage(options, authConfig)
-	return "", err
+	return dockerPushImage(s.dockerClient, name, authConfig)
 }
 
 // buildEnvVars returns a map with build metadata to be inserted into Docker


### PR DESCRIPTION
Replace direct calls to `dockerClient.PullImage()`/`dockerClient.PushImage()` with calls to `dockerPullImage()`/`dockerPushImage()`, which wrap them using `retryImageAction()`, so that we retry them if the fail due to what appears to be a transient error.

This means that we don't get to check if the passed-in reference is a digested or tagged reference, so the daemonless `PushImage()`/`PullImage()` methods can receive a digest as a `Tag` value again.  To cope with that, check if a "tag" can be parsed as a valid digest, and if it can be, just treat it as a digest.