### PR TITLE
Retry pulling or pushing images, for certain errors

### DIFF
--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -194,7 +194,9 @@ func (d *DockerBuilder) pullImage(name string, authConfig docker.AuthConfigurati
 		options.Repository = name
 	}
 
-	return d.dockerClient.PullImage(options, authConfig)
+	return retryImageAction("Pull", func() (pullErr error) {
+		return d.dockerClient.PullImage(options, authConfig)
+	})
 }
 
 func (d *DockerBuilder) pushImage(name string, authConfig docker.AuthConfiguration) (string, error) {
@@ -203,7 +205,9 @@ func (d *DockerBuilder) pushImage(name string, authConfig docker.AuthConfigurati
 		Name: repository,
 		Tag:  tag,
 	}
-	err := d.dockerClient.PushImage(options, authConfig)
+	err := retryImageAction("Push", func() (pushErr error) {
+		return d.dockerClient.PushImage(options, authConfig)
+	})
 	return "", err
 }
 


### PR DESCRIPTION
Replace direct calls to dockerClient.PullImage() and dockerClient.PushImage() with calls that wrap them in retryImageAction(), so that we will retry them if either fail due to what appears to be a transient error.