### PR TITLE
imagecontent/storage.conf: remove nodev from mountopt

### DIFF
--- a/imagecontent/storage.conf
+++ b/imagecontent/storage.conf
@@ -33,7 +33,7 @@ size = ""
 override_kernel_check = "false"
 
 # mountopt specifies comma separated list of extra mount options
-mountopt = "nodev"
+mountopt = ""
 
 # Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
 # a container, to UIDs/GIDs as they should appear outside of the container, and


### PR DESCRIPTION
Causes the following warning in builds:

time="2018-11-12T20:04:10Z" level=warning msg="Not using native diff for overlay, this may cause degraded performance for building images: failed to mount overlay: invalid argument"

we can see the following in dmseg

[63095.446247] overlayfs: unrecognized mount option "nodev" or missing value

Applying nodev everywhere is also not right and we already
revomed/reverted such behavior recently introduced in CRI-O.

Signed-off-by: Antonio Murdaca <runcom@linux.com>