### PR TITLE
Heed the ImageOptimizationPolicy

### DIFF
--- a/pkg/build/builder/daemonless_unsupported.go
+++ b/pkg/build/builder/daemonless_unsupported.go
@@ -53,6 +53,6 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 }
 
 // GetDaemonlessClient returns an error.
-func GetDaemonlessClient(systemContext types.SystemContext, store storage.Store, isolationSpec, blobCacheDirectory string) (client DockerClient, err error) {
+func GetDaemonlessClient(systemContext types.SystemContext, store storage.Store, isolationSpec, blobCacheDirectory string, imageOptimizationPolicy buildapiv1.ImageOptimizationPolicy) (client DockerClient, err error) {
 	return nil, errors.New("building images without an engine not supported on this platform")
 }

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -354,16 +354,6 @@ func (d *DockerBuilder) dockerBuild(ctx context.Context, dir string, tag string)
 		opts.AuthConfigs = *auth
 	}
 
-	/*
-		// TODO: pass this to buildah
-			imageOptimizationPolicy := buildapiv1.ImageOptimizationNone
-			if s := d.build.Spec.Strategy.DockerStrategy; s != nil {
-				if policy := s.ImageOptimizationPolicy; policy != nil {
-					imageOptimizationPolicy = *policy
-				}
-			}
-	*/
-
 	return d.dockerClient.BuildImage(opts)
 }
 


### PR DESCRIPTION
Pass the build's configured `ImageOptimizationPolicy` down to the build logic by keeping track of it in the `DaemonlessClient`.