### PR TITLE
Process $DROP_CAPS

### DIFF
--- a/pkg/build/builder/daemonless_test.go
+++ b/pkg/build/builder/daemonless_test.go
@@ -1,0 +1,32 @@
+package builder
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	builderutil "github.com/openshift/builder/pkg/build/builder/util"
+)
+
+func TestParseDropCapabilities(t *testing.T) {
+	tests := map[string][]string{
+		"SYS_ADMIN": {"CAP_SYS_ADMIN"},
+		"cap_chown,dac_override,cap_dac_read_search,FOWNER,CAP_FSETID": {"CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_DAC_READ_SEARCH", "CAP_FOWNER", "CAP_FSETID"},
+	}
+	preserveEnv, preserveSet := os.LookupEnv(builderutil.DropCapabilities)
+	for input, expected := range tests {
+		if err := os.Setenv(builderutil.DropCapabilities, input); err != nil {
+			t.Errorf("%s: %v", input, err)
+			continue
+		}
+		actual := dropCapabilities()
+		if strings.Join(actual, ";") != strings.Join(expected, ";") {
+			t.Errorf("%s: expected %v, got %v", input, expected, actual)
+		}
+	}
+	if preserveSet {
+		os.Setenv(builderutil.DropCapabilities, preserveEnv)
+	} else {
+		os.Unsetenv(builderutil.DropCapabilities)
+	}
+}

--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -403,11 +403,12 @@ func extractSourceFromImage(ctx context.Context, dockerClient DockerClient, stor
 	}
 
 	builderOptions := buildah.BuilderOptions{
-		FromImage:       image,
-		PullPolicy:      pullPolicy,
-		ReportWriter:    os.Stdout,
-		SystemContext:   &systemContext,
-		CommonBuildOpts: &buildah.CommonBuildOptions{},
+		FromImage:        image,
+		PullPolicy:       pullPolicy,
+		ReportWriter:     os.Stdout,
+		SystemContext:    &systemContext,
+		CommonBuildOpts:  &buildah.CommonBuildOptions{},
+		DropCapabilities: dropCapabilities(),
 	}
 
 	builder, err := buildah.NewBuilder(ctx, store, builderOptions)


### PR DESCRIPTION
Process $DROP_CAPS (example value: "KILL,MKNOD,SETGID,SETUID,SYS_CHROOT") by splitting it at commas, upper-casing it, prefixing each value with "CAP_" if it doesn't already start with that prefix, and setting it in the `DropCapabilities` list in our `BuildOptions`.