### PR TITLE
Workaround bug 1677818 in microdnf for new UBI base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN INSTALL_PKGS=" \
       git tar bsdtar \
       " && \
     yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
     yum clean all
 COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/bin/
 COPY imagecontent/policy.json /etc/containers/

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -9,7 +9,6 @@ RUN INSTALL_PKGS=" \
       git tar bsdtar \
       " && \
     yum install -y ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     yum clean all
 
 COPY imagecontent/policy.json /etc/containers/

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,7 +10,6 @@ RUN INSTALL_PKGS=" \
       git tar bsdtar \
       " && \
     yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
     yum clean all
 COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/bin/
 COPY imagecontent/policy.json /etc/containers/


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1677818 causes an error
when we run rpm -V on findutils. While we transition to microdnf
remove the verification check (which protects against an issue
that only yum has but microdnf/dnf do not have).