### PR TITLE
S2IBuilder.pullImage: retry pulls

### DIFF
--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -451,7 +451,9 @@ func (s *S2IBuilder) pullImage(name string, authConfig dockerclient.AuthConfigur
 		options.Repository = name
 	}
 
-	return s.dockerClient.PullImage(options, authConfig)
+	return retryImageAction("Pull", func() (pullErr error) {
+		return s.dockerClient.PullImage(options, authConfig)
+	})
 }
 
 func (s *S2IBuilder) buildImage(optimization buildapiv1.ImageOptimizationPolicy, opts dockerclient.BuildImageOptions) error {


### PR DESCRIPTION
Wrap S2IBuilder.pullImage's attempts to pull an image with retryImageAction(), to match its push logic and the pull and push logic that we use for builds that use the Docker strategy.

This should fix #45.