### PR TITLE
Drop unused copyImageSource() function

### DIFF
--- a/pkg/build/builder/daemonless_unsupported.go
+++ b/pkg/build/builder/daemonless_unsupported.go
@@ -33,9 +33,6 @@ func (d *DaemonlessClient) RemoveImage(name string) error {
 func (d *DaemonlessClient) CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error) {
 	return nil, errors.New("creating containers not supported on this platform")
 }
-func (d *DaemonlessClient) DownloadFromContainer(id string, opts docker.DownloadFromContainerOptions) error {
-	return errors.New("downloading data containers not supported on this platform")
-}
 func (d *DaemonlessClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
 	return errors.New("pulling images not supported on this platform")
 }

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -12,8 +12,6 @@ import (
 	"github.com/docker/docker/builder/dockerfile/parser"
 	docker "github.com/fsouza/go-dockerclient"
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
-	"github.com/openshift/source-to-image/pkg/tar"
-	s2ifs "github.com/openshift/source-to-image/pkg/util/fs"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +30,6 @@ const defaultDockerfilePath = "Dockerfile"
 // DockerBuilder builds Docker images given a git repository URL
 type DockerBuilder struct {
 	dockerClient DockerClient
-	tar          tar.Tar
 	build        *buildapiv1.Build
 	client       buildclientv1.BuildInterface
 	cgLimits     *s2iapi.CGroupLimits
@@ -44,7 +41,6 @@ func NewDockerBuilder(dockerClient DockerClient, buildsClient buildclientv1.Buil
 	return &DockerBuilder{
 		dockerClient: dockerClient,
 		build:        build,
-		tar:          tar.New(s2ifs.NewFileSystem()),
 		client:       buildsClient,
 		cgLimits:     cgLimits,
 		inputDir:     InputContentPath,

--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -16,9 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/source-to-image/pkg/tar"
-	s2ifs "github.com/openshift/source-to-image/pkg/util/fs"
-
 	buildapiv1 "github.com/openshift/api/build/v1"
 	"github.com/openshift/builder/pkg/build/builder/util/dockerfile"
 	buildfake "github.com/openshift/client-go/build/clientset/versioned/fake"
@@ -457,7 +454,6 @@ func TestDockerfilePath(t *testing.T) {
 		dockerBuilder := &DockerBuilder{
 			dockerClient: dockerClient,
 			build:        build,
-			tar:          tar.New(s2ifs.NewFileSystem()),
 		}
 
 		// this will validate that the Dockerfile is readable
@@ -585,7 +581,6 @@ USER 1001`
 		client:       client.Build().Builds(""),
 		build:        build,
 		dockerClient: dockerClient,
-		tar:          tar.New(s2ifs.NewFileSystem()),
 		inputDir:     buildDir,
 	}
 	if err := ManageDockerfile(buildDir, build); err != nil {

--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -29,7 +29,6 @@ type DockerClient interface {
 	PushImage(opts docker.PushImageOptions, auth docker.AuthConfiguration) (string, error)
 	RemoveImage(name string) error
 	CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error)
-	DownloadFromContainer(id string, opts docker.DownloadFromContainerOptions) error
 	PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
 	RemoveContainer(opts docker.RemoveContainerOptions) error
 	InspectImage(name string) (*docker.Image, error)

--- a/pkg/build/builder/dockerutil_test.go
+++ b/pkg/build/builder/dockerutil_test.go
@@ -56,9 +56,6 @@ func (d *FakeDocker) RemoveImage(name string) error {
 func (d *FakeDocker) CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error) {
 	return &docker.Container{}, nil
 }
-func (d *FakeDocker) DownloadFromContainer(id string, opts docker.DownloadFromContainerOptions) error {
-	return nil
-}
 func (d *FakeDocker) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
 	if d.pullImageFunc != nil {
 		return d.pullImageFunc(opts, auth)


### PR DESCRIPTION
Remove copyImageSource(), and the DownloadFromContainer() interface member and its daemonless implementation, which we're not using.