### PR TITLE
Bug 1688779: Ensure image exists for incremental builds

### DIFF
--- a/pkg/build/builder/dockerutil_test.go
+++ b/pkg/build/builder/dockerutil_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 type FakeDocker struct {
-	pushImageFunc   func(opts docker.PushImageOptions, auth docker.AuthConfiguration) (string, error)
-	pullImageFunc   func(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
-	buildImageFunc  func(opts docker.BuildImageOptions) error
-	removeImageFunc func(name string) error
+	pushImageFunc    func(opts docker.PushImageOptions, auth docker.AuthConfiguration) (string, error)
+	pullImageFunc    func(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
+	buildImageFunc   func(opts docker.BuildImageOptions) error
+	inspectImageFunc func(name string) (*docker.Image, error)
+	removeImageFunc  func(name string) error
 
 	buildImageCalled  bool
 	pushImageCalled   bool
@@ -66,6 +67,9 @@ func (d *FakeDocker) RemoveContainer(opts docker.RemoveContainerOptions) error {
 	return nil
 }
 func (d *FakeDocker) InspectImage(name string) (*docker.Image, error) {
+	if d.inspectImageFunc != nil {
+		return d.inspectImageFunc(name)
+	}
 	return &docker.Image{}, nil
 }
 func (d *FakeDocker) StartContainer(id string, hostConfig *docker.HostConfig) error {


### PR DESCRIPTION
* Attempt to pull the output image for incremental s2i builds.
* If incremental image does not exist, revert back to a normal s2i build.

Fixes [Bug 1688779](https://bugzilla.redhat.com/show_bug.cgi?id=1688779)