### PR TITLE
Bug 1698152: fix image source extraction with trailing "/."

### DIFF
--- a/pkg/build/builder/source_test.go
+++ b/pkg/build/builder/source_test.go
@@ -304,3 +304,189 @@ func TestCloneFromBranch(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyImageSourceFromFilesystem(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		testFiles   map[string]string
+		testLinks   map[string]string
+		copyPath    string
+		destination string
+		verifyFiles map[string]string
+		verifyLinks map[string]string
+	}{
+		{
+			name: "single file",
+			testFiles: map[string]string{
+				"hello.txt": "Hello world!",
+			},
+			copyPath:    "hello.txt",
+			destination: "dst",
+			verifyFiles: map[string]string{
+				"dst/hello.txt": "Hello world!",
+			},
+		},
+		{
+			name:        "single symlink",
+			destination: "dst",
+			testFiles: map[string]string{
+				"src/hello.txt": "Hello world!",
+			},
+			testLinks: map[string]string{
+				"link/hello.txt": "../hello.txt",
+			},
+			copyPath: "link/hello.txt",
+			verifyLinks: map[string]string{
+				"dst/hello.txt": "../hello.txt",
+			},
+		},
+		{
+			name:        "path preserving parent directory",
+			copyPath:    "src",
+			destination: "dst",
+			testFiles: map[string]string{
+				"src/foo/hello.txt": "Hello world!",
+				"src/foo/foo.txt":   "bar",
+			},
+			testLinks: map[string]string{
+				"src/bar/link.txt": "../hello.txt",
+			},
+			verifyFiles: map[string]string{
+				"dst/src/foo/hello.txt": "Hello world!",
+				"dst/src/foo/foo.txt":   "bar",
+			},
+			verifyLinks: map[string]string{
+				"dst/src/bar/link.txt": "../hello.txt",
+			},
+		},
+		{
+			name:        "path removing parent directory",
+			copyPath:    "src/.",
+			destination: "dst",
+			testFiles: map[string]string{
+				"src/foo/hello.txt": "Hello world!",
+				"src/foo/foo.txt":   "bar",
+			},
+			testLinks: map[string]string{
+				"src/bar/link.txt": "../hello.txt",
+			},
+			verifyFiles: map[string]string{
+				"dst/foo/hello.txt": "Hello world!",
+				"dst/foo/foo.txt":   "bar",
+			},
+			verifyLinks: map[string]string{
+				"dst/bar/link.txt": "../hello.txt",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testDir, err := ioutil.TempDir("", "copy-src-from-fs")
+			if err != nil {
+				t.Fatalf("failed to create test directory: %v", err)
+			}
+			defer os.RemoveAll(testDir)
+			for fileName, data := range tc.testFiles {
+				err = createTestFile(testDir, fileName, data)
+				if err != nil {
+					t.Fatalf("failed to create test file %s: %v", fileName, err)
+				}
+			}
+			for linkName, linkSrc := range tc.testLinks {
+				err = createTestSymlink(testDir, linkName, linkSrc)
+				if err != nil {
+					t.Fatalf("failed to create test symlink %s: %v", linkName, err)
+				}
+			}
+			dstDir := filepath.Join(testDir, tc.destination)
+			copySrc := fmt.Sprintf("%s/%s", testDir, tc.copyPath)
+			t.Logf("copying %s to %s", copySrc, dstDir)
+			err = copyImageSourceFromFilesytem(copySrc, dstDir)
+			if err != nil {
+				t.Errorf("unexpected error occurred: %v", err)
+			}
+			for f, d := range tc.verifyFiles {
+				fileName := filepath.Join(testDir, f)
+				verifyFile(fileName, d, t)
+			}
+			for l, src := range tc.verifyLinks {
+				linkName := filepath.Join(testDir, l)
+				verifyLink(linkName, src, t)
+			}
+		})
+	}
+}
+
+func createTestFile(testDir string, filename string, content string) error {
+	file := filepath.Join(testDir, filename)
+	fileDir := filepath.Dir(file)
+	if _, err := os.Stat(fileDir); err != nil {
+		err = os.MkdirAll(fileDir, 0777)
+		if err != nil {
+			return err
+		}
+	}
+	return ioutil.WriteFile(file, []byte(content), 0644)
+}
+
+func createTestSymlink(testDir string, linkname string, source string) error {
+	file := filepath.Join(testDir, linkname)
+	fileDir := filepath.Dir(file)
+	if _, err := os.Stat(fileDir); err != nil {
+		err = os.MkdirAll(fileDir, 0777)
+		if err != nil {
+			return err
+		}
+	}
+	return os.Symlink(source, file)
+}
+
+func verifyFile(filename string, expectedContent string, t *testing.T) {
+	info, err := os.Lstat(filename)
+	if err != nil {
+		t.Fatalf("failed to lstat %s: %v", filename, err)
+	}
+	if info.IsDir() {
+		t.Errorf("expected regular file for %s, got directory", filename)
+	}
+	switch mode := info.Mode(); {
+	case mode&os.ModeSymlink != 0:
+		t.Errorf("expected regular file for %s, got symlink", filename)
+	case mode.IsRegular():
+		data, err := ioutil.ReadFile(filename)
+		if err != nil {
+			t.Errorf("could not read %s: %v", filename, err)
+		}
+		if string(data) != expectedContent {
+			t.Errorf("expected file content %q, got %q", string(expectedContent), string(data))
+		}
+	default:
+		t.Errorf("file %s is not a regular file, mode is: %v", filename, mode)
+	}
+}
+
+func verifyLink(filename string, expectedSrc string, t *testing.T) {
+	info, err := os.Lstat(filename)
+	if err != nil {
+		t.Fatalf("failed to lstat %s: %v", filename, err)
+	}
+	if info.IsDir() {
+		t.Errorf("expected symlink for %s, got directory", filename)
+	}
+	switch mode := info.Mode(); {
+	case mode&os.ModeSymlink != 0:
+		linkSrc, err := os.Readlink(filename)
+		if err != nil {
+			// Should be able to read the symlink
+			t.Errorf("failed to read symlink for %s: %v", filename, err)
+		}
+		if linkSrc != expectedSrc {
+			t.Errorf("expected link source for %s to be %q, got %q", filename, expectedSrc, linkSrc)
+		}
+	case mode.IsRegular():
+		t.Errorf("expected symlink for %s, got regular file", filename)
+	default:
+		t.Errorf("file %s is not a symlink, mode is: %v", filename, mode)
+	}
+}


### PR DESCRIPTION
* Fix copy behavior if the image source path ends with "/."
* Add unit tests for copying regular files and symlinks

/assign @coreydaley 

/cc @bparees 

fyi @openshift/sig-developer-experience 