### PR TITLE
Change containers to allow building without privilege.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 RUN INSTALL_PKGS=" \
-      which tar wget hostname sysvinit-tools util-linux \
-      socat tree findutils lsof bind-utils \
-      git tar bsdtar \
+      bind-utils bsdtar findutils fuse-overlayfs git hostname lsof socat \
+      sysvinit-tools tar tree util-linux wget which \
       " && \
     yum install -y $INSTALL_PKGS && \
     yum clean all
@@ -15,7 +14,11 @@ COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/
 COPY imagecontent/policy.json /etc/containers/
 COPY imagecontent/registries.conf /etc/containers/
 COPY imagecontent/storage.conf /etc/containers/
-RUN mkdir /var/cache/blobs
+RUN mkdir -p /var/cache/blobs \
+    /var/lib/shared/overlay-images \
+    /var/lib/shared/overlay-layers && \
+    touch /var/lib/shared/overlay-images/images.lock \
+    /var/lib/shared/overlay-layers/layers.lock
 
 RUN ln -s /usr/bin/openshift-builder /usr/bin/openshift-sti-build && \
     ln -s /usr/bin/openshift-builder /usr/bin/openshift-docker-build && \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -4,9 +4,8 @@ LABEL io.k8s.display-name="OpenShift Origin Builder" \
       io.openshift.tags="openshift,builder"
 
 RUN INSTALL_PKGS=" \
-      which tar wget hostname sysvinit-tools util-linux \
-      socat tree findutils lsof bind-utils \
-      git tar bsdtar \
+      bind-utils bsdtar findutils fuse-overlayfs git hostname lsof socat \
+      sysvinit-tools tar tree util-linux wget which \
       " && \
     yum install -y ${INSTALL_PKGS} && \
     yum clean all
@@ -14,7 +13,11 @@ RUN INSTALL_PKGS=" \
 COPY imagecontent/policy.json /etc/containers/
 COPY imagecontent/registries.conf /etc/containers/
 COPY imagecontent/storage.conf /etc/containers/
-RUN mkdir /var/cache/blobs
+RUN mkdir -p /var/cache/blobs \
+    /var/lib/shared/overlay-images \
+    /var/lib/shared/overlay-layers && \
+    touch /var/lib/shared/overlay-images/images.lock \
+    /var/lib/shared/overlay-layers/layers.lock
 
 COPY openshift-builder /usr/bin
 RUN ln -s /usr/bin/openshift-builder /usr/bin/openshift-sti-build && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -5,9 +5,8 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 RUN INSTALL_PKGS=" \
-      which tar wget hostname sysvinit-tools util-linux \
-      socat tree findutils lsof bind-utils \
-      git tar bsdtar \
+      bind-utils bsdtar findutils git hostname lsof socat \
+      sysvinit-tools tar tree util-linux wget which \
       " && \
     yum install -y $INSTALL_PKGS && \
     yum clean all
@@ -15,7 +14,11 @@ COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/
 COPY imagecontent/policy.json /etc/containers/
 COPY imagecontent/registries.conf /etc/containers/
 COPY imagecontent/storage.conf /etc/containers/
-RUN mkdir /var/cache/blobs
+RUN mkdir -p /var/cache/blobs \
+    /var/lib/shared/overlay-images \
+    /var/lib/shared/overlay-layers && \
+    touch /var/lib/shared/overlay-images/images.lock \
+    /var/lib/shared/overlay-layers/layers.lock
 
 RUN ln -s /usr/bin/openshift-builder /usr/bin/openshift-sti-build && \
     ln -s /usr/bin/openshift-builder /usr/bin/openshift-docker-build && \

--- a/imagecontent/storage.conf
+++ b/imagecontent/storage.conf
@@ -19,6 +19,7 @@ graphroot = "/var/lib/containers/storage"
 # AdditionalImageStores is used to pass paths to additional Read/Only image stores
 # Must be comma separated list.
 additionalimagestores = [
+"/var/lib/shared",
 ]
 
 # Size is used to set a maximum size of the container image.  Only supported by
@@ -28,9 +29,6 @@ size = ""
 # Path to an helper program to use for mounting the file system instead of mounting it
 # directly.
 #mount_program = "/usr/bin/fuse-overlayfs"
-
-# OverrideKernelCheck tells the driver to ignore kernel checks based on kernel version
-override_kernel_check = "false"
 
 # mountopt specifies comma separated list of extra mount options
 mountopt = ""
@@ -55,13 +53,6 @@ mountopt = ""
 #
 # remap-user = "storage"
 # remap-group = "storage"
-
-# If specified, use OSTree to deduplicate files with the overlay backend
-ostree_repo = ""
-
-# Set to skip a PRIVATE bind mount on the storage home directory.  Only supported by
-# certain container storage drivers
-skip_mount_home = "false"
 
 [storage.options.thinpool]
 # Storage Options for thinpool
@@ -114,7 +105,7 @@ skip_mount_home = "false"
 # mkfsarg = ""
 
 # use_deferred_removal marks devicemapper block device for deferred removal.
-# If the thinpool is in use when the driver attempts to remove it, the driver 
+# If the thinpool is in use when the driver attempts to remove it, the driver
 # tells the kernel to remove it as soon as possible. Note this does not free
 # up the disk space, use deferred deletion to fully remove the thinpool.
 # use_deferred_removal = "True"

--- a/pkg/build/builder/util/consts.go
+++ b/pkg/build/builder/util/consts.go
@@ -26,7 +26,7 @@ const (
 	StatusMessageFetchSourceFailed               = "Failed to fetch the input source."
 	StatusMessageInvalidContextDirectory         = "The supplied context directory does not exist."
 	StatusMessageCancelledBuild                  = "The build was cancelled by the user."
-	StatusMessageDockerBuildFailed               = "Docker build strategy has failed."
+	StatusMessageDockerBuildFailed               = "Dockerfile build strategy has failed."
 	StatusMessageBuildPodExists                  = "The pod for this build already exists and is older than the build."
 	StatusMessageNoBuildContainerStatus          = "The pod for this build has no container statuses indicating success or failure."
 	StatusMessageFailedContainer                 = "The pod for this build has at least one container with a non-zero exit status."


### PR DESCRIPTION
By turning on fuse-overlayfs, the container can run without the
--privileged flag.

Also setup shared directory to allow images to be shared into
the containers via the volume mounts from the host.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>