### PR TITLE
clean up of some CA mount logic that is now handled by the build controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,25 +46,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: Remove this once the config-map based mount approach lands after rebase
-	oldServiceCASrc := fmt.Sprintf("%s/service-ca.crt", builder.SecretCertsMountPath)
-	oldServiceCADst := fmt.Sprintf("%s/service.crt", tlsCertRoot)
-	err = CopyFileIfExists(oldServiceCASrc, oldServiceCADst)
-	if err != nil {
-		fmt.Printf("Error setting up service CA cert: %v", err)
-		os.Exit(1)
-	}
-
-	// TODO: Remove this once the build controller mounts the internal registry's CA
-	// in certs.d/<internal-registry-hostname>/
-	newServiceCASrc := fmt.Sprintf("%s/service-ca.crt", builder.ConfigMapCertsMountPath)
-	newServiceCADst := fmt.Sprintf("%s/openshift-service.crt", tlsCertRoot)
-	err = CopyFileIfExists(newServiceCASrc, newServiceCADst)
-	if err != nil {
-		fmt.Printf("Error setting up service CA cert: %v", err)
-		os.Exit(1)
-	}
-
 	runtimeCASrc := fmt.Sprintf("%s/certs.d", builder.ConfigMapCertsMountPath)
 	err = CopyDirIfExists(runtimeCASrc, runtimeCertRoot)
 	if err != nil {


### PR DESCRIPTION

@openshift/openshift-team-developer-experience @bparees @nalind  FYI

/assign @adambkaplan 

An initial stab into modfications to openshift/builder in light of the 4.2 global CA injection work, along with reconciling some older TODOs I think are now handled by the build controller

My first openshift/builder PR :-)