### PR TITLE
Remove fuse-overlayfs from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ COPY . .
 RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+# TODO: Add fuse-overlayfs once we build off of RHEL-8 UBI
 RUN INSTALL_PKGS=" \
-      bind-utils bsdtar findutils fuse-overlayfs git hostname lsof socat \
+      bind-utils bsdtar findutils git hostname lsof socat \
       sysvinit-tools tar tree util-linux wget which \
       " && \
-    yum install -y $INSTALL_PKGS && \
+    yum install -y --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all
 COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/bin/
 COPY imagecontent/policy.json /etc/containers/

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,11 +3,12 @@ LABEL io.k8s.display-name="OpenShift Origin Builder" \
       io.k8s.description="This is a component of OpenShift Origin and is responsible for executing image builds." \
       io.openshift.tags="openshift,builder"
 
+# TODO: Add fuse-overlayfs once we build off of RHEL-8 UBI
 RUN INSTALL_PKGS=" \
-      bind-utils bsdtar findutils fuse-overlayfs git hostname lsof socat \
+      bind-utils bsdtar findutils git hostname lsof socat \
       sysvinit-tools tar tree util-linux wget which \
       " && \
-    yum install -y ${INSTALL_PKGS} && \
+    yum install -y --setopt=skip_missing_names_on_install=False ${INSTALL_PKGS} && \
     yum clean all
 
 COPY imagecontent/policy.json /etc/containers/

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -4,11 +4,12 @@ COPY . .
 RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
+# TODO: Add fuse-overlayfs once we build off of RHEL-8 UBI
 RUN INSTALL_PKGS=" \
       bind-utils bsdtar findutils git hostname lsof socat \
       sysvinit-tools tar tree util-linux wget which \
       " && \
-    yum install -y $INSTALL_PKGS && \
+    yum install -y --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all
 COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/bin/
 COPY imagecontent/policy.json /etc/containers/


### PR DESCRIPTION
fuse-overlayfs is not available in RHEL 7.
This is causing ART builds for 4.2 to fail.