### PR TITLE
[release-4.3] strip the tag from the reference we print after pushing

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -293,7 +293,7 @@ func pushDaemonlessImage(sc types.SystemContext, store storage.Store, imageName 
 	logName := imageName
 	if dref := dest.DockerReference(); dref != nil {
 		if named, ok := dref.(ireference.Named); ok {
-			if canonical, err := ireference.WithDigest(named, digest); err == nil {
+			if canonical, err := ireference.WithDigest(ireference.TrimNamed(named), digest); err == nil {
 				logName = canonical.String()
 			}
 		}


### PR DESCRIPTION
When we combine the image name that we pushed to with a digest in order to print the "Successfully pushed..." message, strip out the tag.  Cherry-picked from #89.