### PR TITLE
Bug 1746499: Add ":latest" to push tag if none is specified

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -215,9 +215,10 @@ func tagDaemonlessImage(sc types.SystemContext, store storage.Store, buildTag, p
 	if img == nil {
 		return storage.ErrImageUnknown
 	}
-	if err := store.SetNames(img.ID, append(img.Names, pushTag)); err != nil {
+	if err := util.AddImageNames(store, "", &systemContext, img, []string{pushTag}); err != nil {
 		return err
 	}
+	log.V(2).Infof("Added name %q to local image.", pushTag)
 
 	return nil
 }


### PR DESCRIPTION
Use `util.AddImageNames()` to add the `pushTag` to our just-built image, so that the name we apply will include a "latest" tag if one wasn't directly specified.

The `AddImageNames()` function ultimately expands the name we give it, in the same way that Push() does with the name we give it, so this should resolve cases where we would add a name with `SetNames()` that `Push()` would then be unable to use to find the image.