### PR TITLE
Bug 1747937: Forwarding HTTPProxy environment variables.

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -179,6 +179,7 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 			{Name: string(specs.NetworkNamespace), Host: true},
 		},
 		CommonBuildOpts: &buildah.CommonBuildOptions{
+			HTTPProxy:    true,
 			Memory:       opts.Memory,
 			MemorySwap:   opts.Memswap,
 			CgroupParent: opts.CgroupParent,
@@ -400,6 +401,7 @@ func daemonlessRun(ctx context.Context, store storage.Store, isolation buildah.I
 		Container: createOpts.Name,
 		FromImage: createOpts.Config.Image,
 		CommonBuildOpts: &buildah.CommonBuildOptions{
+			HTTPProxy:    true,
 			Memory:       createOpts.HostConfig.Memory,
 			MemorySwap:   createOpts.HostConfig.MemorySwap,
 			CgroupParent: createOpts.HostConfig.CgroupParent,

--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -401,8 +401,10 @@ func extractSourceFromImage(ctx context.Context, dockerClient DockerClient, stor
 		PullPolicy:       pullPolicy,
 		ReportWriter:     os.Stdout,
 		SystemContext:    &systemContext,
-		CommonBuildOpts:  &buildah.CommonBuildOptions{},
 		DropCapabilities: dropCapabilities(),
+		CommonBuildOpts: &buildah.CommonBuildOptions{
+			HTTPProxy: true,
+		},
 	}
 
 	builder, err := buildah.NewBuilder(ctx, store, builderOptions)


### PR DESCRIPTION
This patch sets HTTPProxy option on buildah.CommonBuildOptions to true,
that will cause Buildah to forward HTTPProxy environment variables down
the line.