### PR TITLE
Bug 1713671: toggle ssh parameters if ssh-auth source secret includes a known_host…

### DIFF
--- a/pkg/build/builder/cmd/scmauth/sshkey.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey.go
@@ -1,11 +1,13 @@
 package scmauth
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 )
 
 const SSHPrivateKeyMethodName = "ssh-privatekey"
+const knownHostsFileName = "known_hosts"
 
 // SSHPrivateKey implements SCMAuth interface for using SSH private keys.
 type SSHPrivateKey struct{}
@@ -21,10 +23,31 @@ func (_ SSHPrivateKey) Setup(baseDir string, context SCMAuthContext) error {
 	if err := script.Chmod(0711); err != nil {
 		return err
 	}
-	content := "#!/bin/sh\nssh -i " +
-		filepath.Join(baseDir, SSHPrivateKeyMethodName) +
-		" -o StrictHostKeyChecking=false \"$@\"\n"
-
+	foundPrivateKey := false
+	foundKnownHosts := false
+	files, err := ioutil.ReadDir(baseDir)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		switch {
+		case file.Name() == knownHostsFileName:
+			foundKnownHosts = true
+		case file.Name() == SSHPrivateKeyMethodName:
+			foundPrivateKey = true
+		}
+		glog.V(5).Infof("source secret dir %s has file %s", baseDir, file.Name())
+	}
+	if !foundPrivateKey {
+		return fmt.Errorf("could not find the ssh-privatekey file for the ssh secret stored at %s", baseDir)
+	}
+	// let's see if known_hosts was included in the secret
+	content := "#!/bin/sh\nssh -i " + filepath.Join(baseDir, SSHPrivateKeyMethodName)
+	if !foundKnownHosts {
+		content = content + " -o StrictHostKeyChecking=false \"$@\"\n"
+	} else {
+		content = content + " -o UserKnownHostsFile=" + filepath.Join(baseDir, knownHostsFileName) + " \"$@\"\n"
+	}
 	glog.V(5).Infof("Adding Private SSH Auth:\n%s\n", content)
 
 	if _, err := script.WriteString(content); err != nil {

--- a/pkg/build/builder/cmd/scmauth/sshkey_test.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey_test.go
@@ -1,7 +1,9 @@
 package scmauth
 
 import (
+	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -25,8 +27,40 @@ func TestSSHPrivateKeySetup(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
-	_, isSet := context.Get("GIT_SSH")
+	fileName, isSet := context.Get("GIT_SSH")
 	if !isSet {
 		t.Errorf("GIT_SSH is not set")
+	}
+	buf, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Errorf("problem reading ssh file %s", err.Error())
+	}
+	str := string(buf)
+	if !strings.Contains(str, "StrictHostKeyChecking") {
+		t.Errorf("ssh script had wrong contents %s", str)
+	}
+}
+
+func TestSSHPrivateKeyWithKnownHostsSetup(t *testing.T) {
+	context := NewDefaultSCMContext()
+	sshKey := &SSHPrivateKey{}
+	secretDir := secretDir(t, "ssh-privatekey", "known_hosts")
+	defer os.RemoveAll(secretDir)
+
+	err := sshKey.Setup(secretDir, context)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	fileName, isSet := context.Get("GIT_SSH")
+	if !isSet {
+		t.Errorf("GIT_SSH is not set")
+	}
+	buf, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Errorf("problem reading ssh file %s", err.Error())
+	}
+	str := string(buf)
+	if !strings.Contains(str, "UserKnownHostsFile") {
+		t.Errorf("ssh script had wrong contents %s", str)
 	}
 }


### PR DESCRIPTION
…s setting

/assign @adambkaplan 

@openshift/openshift-team-developer-experience 

cherrypick bot was unable to generate 4.1 PR from the 4.2 PR.  See https://github.com/openshift/builder/pull/96#issuecomment-531324195

