### PR TITLE
ensure global CA injected certs are included in gitconfig sslCAInfo

### DIFF
--- a/pkg/build/builder/cmd/scmauth/injectedpem.go
+++ b/pkg/build/builder/cmd/scmauth/injectedpem.go
@@ -1,0 +1,45 @@
+package scmauth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
+)
+
+const (
+	PEMName = "tls-ca-bundle.pem"
+)
+
+// InjectedPem implements SCMAuth interface for pem files injected by global CA support
+type InjectedPem struct {
+	SourceURL s2igit.URL
+}
+
+// Setup creates a .gitconfig fragment that points to the given ca.crt
+func (s InjectedPem) Setup(baseDir string, context SCMAuthContext) error {
+	if !(s.SourceURL.Type == s2igit.URLTypeURL && s.SourceURL.URL.Scheme == "https" && s.SourceURL.URL.Opaque == "") {
+		return nil
+	}
+	gitconfig, err := ioutil.TempFile("", "ca.pem.")
+	if err != nil {
+		return err
+	}
+	defer gitconfig.Close()
+	content := fmt.Sprintf(CACertConfig, filepath.Join(baseDir, PEMName))
+	log.V(5).Infof("Adding CACert Auth to %s:\n%s\n", gitconfig.Name(), content)
+	gitconfig.WriteString(content)
+
+	return ensureGitConfigIncludes(gitconfig.Name(), context)
+}
+
+// Name returns the name of this auth method.
+func (_ InjectedPem) Name() string {
+	return PEMName
+}
+
+// Handles returns true if the secret is a CA certificate
+func (_ InjectedPem) Handles(name string) bool {
+	return name == PEMName
+}

--- a/pkg/build/builder/cmd/scmauth/injectedpem_test.go
+++ b/pkg/build/builder/cmd/scmauth/injectedpem_test.go
@@ -1,0 +1,53 @@
+package scmauth
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/scm/git"
+)
+
+func TestPemHandles(t *testing.T) {
+	pem := &InjectedPem{}
+	if !pem.Handles("tls-ca-bundle.pem") {
+		t.Errorf("should handle tls-ca-bundle.pem")
+	}
+	if pem.Handles("username") {
+		t.Errorf("should not handle username")
+	}
+}
+
+func TestPemSetup(t *testing.T) {
+	context := NewDefaultSCMContext()
+	pem := &InjectedPem{
+		SourceURL: *git.MustParse("https://my.host/git/repo"),
+	}
+	secretDir := secretDir(t, "tls-ca-bundle.pem")
+	defer os.RemoveAll(secretDir)
+
+	err := pem.Setup(secretDir, context)
+	gitConfig, _ := context.Get("GIT_CONFIG")
+	defer cleanupConfig(gitConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	validateConfig(t, gitConfig, "sslCAInfo")
+}
+
+func TestPemSetupNoSSL(t *testing.T) {
+	context := NewDefaultSCMContext()
+	pem := &InjectedPem{
+		SourceURL: *git.MustParse("http://my.host/git/repo"),
+	}
+	secretDir := secretDir(t, "tls-ca-bundle.pem")
+	defer os.RemoveAll(secretDir)
+
+	err := pem.Setup(secretDir, context)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, gitConfigPresent := context.Get("GIT_CONFIG")
+	if gitConfigPresent {
+		t.Fatalf("git config not expected")
+	}
+}

--- a/pkg/build/builder/cmd/scmauth/scmauths.go
+++ b/pkg/build/builder/cmd/scmauth/scmauths.go
@@ -17,6 +17,7 @@ func GitAuths(sourceURL *s2igit.URL) SCMAuths {
 		&UsernamePassword{SourceURL: *sourceURL},
 		&CACert{SourceURL: *sourceURL},
 		&GitConfig{},
+		&InjectedPem{SourceURL: *sourceURL},
 	}
 	return auths
 }


### PR DESCRIPTION
/assign @bparees 
/assign @adambkaplan 
/assign @ricardomaraschini 

this is the alternative to https://github.com/openshift/builder/pull/99 where we don't bump git to the later version provided by SCL on rhel7, but instead always insure that the cert injected by global CA support is included in the gitconfig

if we go with this approach instead I'll tag this bug to https://bugzilla.redhat.com/show_bug.cgi?id=1750650