### PR TITLE
Bug 1755140: do not force skip tls verify to true on image source injection

### DIFF
--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -380,10 +380,6 @@ func extractSourceFromImage(ctx context.Context, dockerClient DockerClient, stor
 	var systemContext types.SystemContext
 	systemContext.AuthFilePath = "/tmp/config.json"
 
-	// TODO remove this, get CAs+insecure registry config from host.
-	systemContext.OCIInsecureSkipTLSVerify = true
-	systemContext.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
-
 	if auths != nil {
 		for registry, ac := range auths.Configs {
 			log.V(5).Infof("Setting authentication for registry %q using %q.", registry, ac.ServerAddress)


### PR DESCRIPTION
/assign @adambkaplan 

@openshift/openshift-team-developer-experience FYI

The registry.conf built by the OCM and passed to openshift/builder should have the correct settings based on what has been supplied to the build config for pulling in source from an image, or from any global image config that has been created.