### PR TITLE
hack/lib/build/version: Use BUILD_VERSION and SOURCE_GIT_COMMIT if non-empty

### DIFF
--- a/hack/lib/build/version.sh
+++ b/hack/lib/build/version.sh
@@ -28,7 +28,9 @@ function os::build::version::git_vars() {
 
 	local git=(git --work-tree "${OS_ROOT}")
 
-	if [[ -n ${OS_GIT_COMMIT-} ]] || OS_GIT_COMMIT=$("${git[@]}" rev-parse --short "HEAD^{commit}" 2>/dev/null); then
+	OS_GIT_COMMIT="${SOURCE_GIT_COMMIT:-${OS_GIT_COMMIT-}}"
+	if [[ -z "${OS_GIT_COMMIT}" ]]; then
+		OS_GIT_COMMIT=$("${git[@]}" rev-parse --short "HEAD^{commit}" 2>/dev/null)
 		if [[ -z ${OS_GIT_TREE_STATE-} ]]; then
 			# Check if the tree is dirty.  default to dirty
 			if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
@@ -37,32 +39,34 @@ function os::build::version::git_vars() {
 				OS_GIT_TREE_STATE="dirty"
 			fi
 		fi
-		# Use git describe to find the version based on annotated tags.
-		if [[ -n ${OS_GIT_VERSION-} ]] || OS_GIT_VERSION=$("${git[@]}" describe --long --tags --abbrev=7 --match 'v[0-9]*' "${OS_GIT_COMMIT}^{commit}" 2>/dev/null); then
-			# Try to match the "git describe" output to a regex to try to extract
-			# the "major" and "minor" versions and whether this is the exact tagged
-			# version or whether the tree is between two tagged versions.
-			if [[ "${OS_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(\.[0-9]+)*([-].*)?$ ]]; then
-				OS_GIT_MAJOR=${BASH_REMATCH[1]}
-				OS_GIT_MINOR=${BASH_REMATCH[2]}
-				OS_GIT_PATCH=${BASH_REMATCH[3]}
-				if [[ -n "${BASH_REMATCH[5]}" ]]; then
-					OS_GIT_MINOR+="+"
-				fi
-			fi
+	fi
 
-			# This translates the "git describe" to an actual semver.org
-			# compatible semantic version that looks something like this:
-			#   v1.1.0-alpha.0.6+84c76d1-345
-			OS_GIT_VERSION=$(echo "${OS_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{7,40\}\)$/\+\2-\1/")
-			# If this is an exact tag, remove the last segment.
-			OS_GIT_VERSION=$(echo "${OS_GIT_VERSION}" | sed "s/-0$//")
-			if [[ "${OS_GIT_TREE_STATE}" == "dirty" ]]; then
-				# git describe --dirty only considers changes to existing files, but
-				# that is problematic since new untracked .go files affect the build,
-				# so use our idea of "dirty" from git status instead.
-				OS_GIT_VERSION+="-dirty"
+	OS_GIT_VERSION="${BUILD_VERSION:-${OS_GIT_VERSION-}}"
+	# Use git describe to find the version based on annotated tags.
+	if [[ -n "${OS_GIT_VERSION}" ]] || OS_GIT_VERSION=$("${git[@]}" describe --long --tags --abbrev=7 --match 'v[0-9]*' "${OS_GIT_COMMIT}^{commit}" 2>/dev/null); then
+		# Try to match the "git describe" output to a regex to try to extract
+		# the "major" and "minor" versions and whether this is the exact tagged
+		# version or whether the tree is between two tagged versions.
+		if [[ "${OS_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(\.[0-9]+)*([-].*)?$ ]]; then
+			OS_GIT_MAJOR=${BASH_REMATCH[1]}
+			OS_GIT_MINOR=${BASH_REMATCH[2]}
+			OS_GIT_PATCH=${BASH_REMATCH[3]}
+			if [[ -n "${BASH_REMATCH[5]}" ]]; then
+				OS_GIT_MINOR+="+"
 			fi
+		fi
+
+		# This translates the "git describe" to an actual semver.org
+		# compatible semantic version that looks something like this:
+		#   v1.1.0-alpha.0.6+84c76d1-345
+		OS_GIT_VERSION=$(echo "${OS_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{7,40\}\)$/\+\2-\1/")
+		# If this is an exact tag, remove the last segment.
+		OS_GIT_VERSION=$(echo "${OS_GIT_VERSION}" | sed "s/-0$//")
+		if [[ "${OS_GIT_TREE_STATE}" == "dirty" ]]; then
+			# git describe --dirty only considers changes to existing files, but
+			# that is problematic since new untracked .go files affect the build,
+			# so use our idea of "dirty" from git status instead.
+			OS_GIT_VERSION+="-dirty"
 		fi
 	fi
 }


### PR DESCRIPTION
Avoid:

```
I0207 15:51:43.662541       1 builder.go:425] openshift-builder v4.3.0-202001211731+b93dcc9-dirty
```

in 4.3.0 builder logs, which is from Git looking at the build directory and seeing:

* The commit b93dcc9, which is in the dist-git repository, not in openshift/builder.  The commit hash logged for 4.3.0 should have been:

    ```console
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.3.0-x86_64 | grep builder
    docker-builder    https://github.com/openshift/builder    50c6e17276dfc7d0acd9d943dac340fb4fa3ff24
    ```

* `-dirty` because Doozer is adjusting our `Dockerfile`?

With this commit we pivot to `BUILD_VERSION` and `SOURCE_GIT_COMMIT`, set by Doozer since [here][1] and [here][2] respectively (internal Red Hat links; sorry external folks).  If either is unset, we fall back to Git calls in the local repository.

[1]: https://gitlab.cee.redhat.com/openshift-art/tools/doozer/commit/b02114a0bb26bbb7f60f1cc484c17fc3172c6df4
[2]: https://gitlab.cee.redhat.com/openshift-art/tools/doozer/commit/204f92b328b28b696cf112444c1da797f8d57fd7