### PR TITLE
[release-4.4] Bug 1821860: manage-dockerfile: use the original form of ENV/LABEL

### DIFF
--- a/pkg/build/builder/util/dockerfile/dockerfile.go
+++ b/pkg/build/builder/util/dockerfile/dockerfile.go
@@ -41,18 +41,8 @@ func Write(node *parser.Node) []byte {
 			}
 			return buf.Bytes()
 		case command.Env, command.Label:
-			for n := node.Next; n != nil; n = n.Next {
-				if buf.Len() > 0 {
-					buf.Write([]byte(" "))
-				}
-				buf.Write([]byte(n.Value))
-				buf.Write([]byte("="))
-				if n.Next != nil {
-					buf.Write([]byte(n.Next.Value))
-				}
-				n = n.Next
-			}
-			buf.Write([]byte("\n"))
+			buf.Reset()
+			buf.Write([]byte(node.Original + "\n"))
 			return buf.Bytes()
 		default:
 			if node.Attributes["json"] {

--- a/pkg/build/builder/util/dockerfile/dockerfile_test.go
+++ b/pkg/build/builder/util/dockerfile/dockerfile_test.go
@@ -61,6 +61,7 @@ LABEL version=1.0
 EXPOSE 8080
 VOLUME /var/run/www
 ENV PATH=/bin TEST=
+ENV OPTS words with whitespace
 ADD file /home/
 COPY dir/ /tmp/
 FROM other as 2
@@ -79,6 +80,7 @@ LABEL version=1.0
 EXPOSE 8080
 VOLUME /var/run/www
 ENV PATH=/bin TEST=
+ENV OPTS words with whitespace
 ADD file /home/
 COPY dir/ /tmp/
 FROM other as 2
@@ -394,6 +396,7 @@ func TestNextValues(t *testing.T) {
 		`EXPOSE 8080`:                   {"8080"},
 		`VOLUME /var/run/www`:           {"/var/run/www"},
 		`ENV PATH=/bin`:                 {"PATH", "/bin"},
+		`ENV OPTS word and whitespace`:  {"OPTS", "word and whitespace"},
 		`ADD file /home/`:               {"file", "/home/"},
 		`COPY dir/ /tmp/`:               {"dir/", "/tmp/"},
 		`RUN echo "Hello world!"`:       {`echo "Hello world!"`},


### PR DESCRIPTION
When rewriting the Dockerfile with our substitutions, we unconditionally insert `=` characters, even in cases where the original file didn't use them.  They're syntactically important, though, so such changes can cause builds to fail.  For ENV and LABEL instructions, just emit the original text.

Cherry-picked from #134.