### PR TITLE
add test for instruction FROM with ARG instruction

### DIFF
--- a/pkg/build/builder/util/dockerfile/dockerfile_test.go
+++ b/pkg/build/builder/util/dockerfile/dockerfile_test.go
@@ -306,6 +306,11 @@ COPY . /boot
 FROM centos:7`,
 			want: []string{"scratch", "centos:7"},
 		},
+		"FROM with ARG": {
+			in: `ARG TAG=7
+FROM centos:$TAG`,
+			want: []string{"centos:7"},
+		},
 	}
 	for name, tc := range testCases {
 		node, err := Parse(strings.NewReader(tc.in))


### PR DESCRIPTION
this works with docker:
```
$ docker build .
Sending build context to Docker daemon  52.74kB
Step 1/2 : ARG TAG=latest
Step 2/2 : FROM centos:$TAG
 ---> 470671670cac
Successfully built 470671670cac
```
version:
```
$ docker version
Client: Docker Engine - Community
 Version:           19.03.8
 API version:       1.40
 Go version:        go1.12.17
 Git commit:        afacb8b
 Built:             Wed Mar 11 01:27:04 2020
 OS/Arch:           linux/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.8
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.17
  Git commit:       afacb8b
  Built:            Wed Mar 11 01:25:42 2020
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.2.13
  GitCommit:        7ad184331fa3e55e52b890ea95e65ba581ae3429
 runc:
  Version:          1.0.0-rc10
  GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683
```