### PR TITLE
Bug 1844596: Bump buildah to v1.14.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
-	github.com/containers/buildah v1.14.9
+	github.com/containers/buildah v1.14.10
 	github.com/containers/common v0.8.4
 	github.com/containers/image/v5 v5.4.3
 	github.com/containers/storage v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784 h1:rqUVLD8I859xRgUx/WMC3v7QAFqbLKZbs+0kqYboRJc=
 github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/containers/buildah v1.14.9 h1:4YNSgXe+KobqMyu6uiUXFu6jHqHAqpT/mnqpEEPwP9A=
-github.com/containers/buildah v1.14.9/go.mod h1:dw9G+L7OAZBdcGTshqNGIrIbChPZfWd3VlBBfEFPE50=
+github.com/containers/buildah v1.14.10 h1:06wfyZInkDLpvQdw9WnOe+KEqvXRjv+EHP/WshpTXPI=
+github.com/containers/buildah v1.14.10/go.mod h1:dw9G+L7OAZBdcGTshqNGIrIbChPZfWd3VlBBfEFPE50=
 github.com/containers/common v0.8.4 h1:G9eNXQHUfZWkEOKaKDpXmDTcjVYc04K77dZe197SH44=
 github.com/containers/common v0.8.4/go.mod h1:VxDJbaA1k6N1TNv9Rt6bQEF4hyKVHNfOfGA5L91ADEs=
 github.com/containers/image/v5 v5.0.0/go.mod h1:MgiLzCfIeo8lrHi+4Lb8HP+rh513sm0Mlk6RrhjFOLY=

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Changelog
 
+## v1.14.10 (2020-06-18)
+    imagebuildah: stages shouldn't count as their base images 
+
 ## v1.14.9 (2020-05-11)
     Bump github.com/containers/common to 0.8.4
 

--- a/vendor/github.com/containers/buildah/buildah.go
+++ b/vendor/github.com/containers/buildah/buildah.go
@@ -27,7 +27,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.14.9"
+	Version = "1.14.10"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/vendor/github.com/containers/buildah/imagebuildah/executor.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/executor.go
@@ -230,7 +230,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 
 // startStage creates a new stage executor that will be referenced whenever a
 // COPY or ADD statement uses a --from=NAME flag.
-func (b *Executor) startStage(stage *imagebuilder.Stage, stages int, from, output string) *StageExecutor {
+func (b *Executor) startStage(stage *imagebuilder.Stage, stages int, output string) *StageExecutor {
 	if b.stages == nil {
 		b.stages = make(map[string]*StageExecutor)
 	}
@@ -245,7 +245,6 @@ func (b *Executor) startStage(stage *imagebuilder.Stage, stages int, from, outpu
 		stage:           stage,
 	}
 	b.stages[stage.Name] = stageExec
-	b.stages[from] = stageExec
 	if idx := strconv.Itoa(stage.Position); idx != stage.Name {
 		b.stages[idx] = stageExec
 	}
@@ -418,7 +417,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			output = b.output
 		}
 
-		stageExecutor := b.startStage(&stage, len(stages), base, output)
+		stageExecutor := b.startStage(&stage, len(stages), output)
 
 		// If this a single-layer build, or if it's a multi-layered
 		// build and b.forceRmIntermediateCtrs is set, make sure we

--- a/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
@@ -295,7 +295,7 @@ func (s *StageExecutor) digestSpecifiedContent(node *parser.Node, argValues []st
 			// container.  Update the ID mappings and
 			// all-content-comes-from-below-this-directory value.
 			from := strings.TrimPrefix(flag, "--from=")
-			if other, ok := s.executor.stages[from]; ok {
+			if other, ok := s.executor.stages[from]; ok && other.index < s.index {
 				contextDir = other.mountPoint
 				idMappingOptions = &other.builder.IDMappingOptions
 			} else if builder, ok := s.executor.containerMap[from]; ok {
@@ -868,13 +868,10 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				if len(arr) != 2 {
 					return "", nil, errors.Errorf("%s: invalid --from flag, should be --from=<name|stage>", command)
 				}
-				otherStage, ok := s.executor.stages[arr[1]]
-				if !ok {
-					if mountPoint, err = s.getImageRootfs(ctx, arr[1]); err != nil {
-						return "", nil, errors.Errorf("%s --from=%s: no stage or image found with that name", command, arr[1])
-					}
-				} else {
+				if otherStage, ok := s.executor.stages[arr[1]]; ok && otherStage.index < s.index {
 					mountPoint = otherStage.mountPoint
+				} else if mountPoint, err = s.getImageRootfs(ctx, arr[1]); err != nil {
+					return "", nil, errors.Errorf("%s --from=%s: no stage or image found with that name", command, arr[1])
 				}
 				s.copyFrom = mountPoint
 				break

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/buildah v1.14.9
+# github.com/containers/buildah v1.14.10
 github.com/containers/buildah
 github.com/containers/buildah/bind
 github.com/containers/buildah/chroot


### PR DESCRIPTION
As the title says, bumping to Buildah v1.14.10.

Addresses this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1844596

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>