### PR TITLE
Bug 1839683: bump github.com/openshift/imagebuilder to v1.1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/openshift/api v0.0.0-20200326160804-ecb9283fe820
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/openshift/imagebuilder v1.1.4
+	github.com/openshift/imagebuilder v1.1.6
 	github.com/openshift/library-go v0.0.0-20200327125526-163b2f0d6264
 	github.com/openshift/source-to-image v1.3.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -716,6 +716,8 @@ github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1Gd
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/imagebuilder v1.1.4 h1:LUg8aTjyXMtlDx6IbtvaqofFGZ6aYqe+VIeATE735LM=
 github.com/openshift/imagebuilder v1.1.4/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
+github.com/openshift/imagebuilder v1.1.6 h1:1+YzRxIIefY4QqtCImx6rg+75QrKNfBoPAKxgMo/khM=
+github.com/openshift/imagebuilder v1.1.6/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/openshift/library-go v0.0.0-20200327125526-163b2f0d6264 h1:VcZjTupwjxB9ANlKxerMNdfjqlTBWrVxgrjKi7VBwOY=
 github.com/openshift/library-go v0.0.0-20200327125526-163b2f0d6264/go.mod h1:CfydoH0B+RYs22uQZQ36A1mz5m5zhucpMGh8t5s71v4=
 github.com/openshift/moby-moby v1.4.2-0.20190308215630-da810a85109d h1:1LuQzDKgiXj1omPNDcY1E/mEOE/90jdobR+7WBfBQYA=

--- a/vendor/github.com/openshift/imagebuilder/builder.go
+++ b/vendor/github.com/openshift/imagebuilder/builder.go
@@ -332,10 +332,19 @@ func ParseFile(path string) (*parser.Node, error) {
 
 // Step creates a new step from the current state.
 func (b *Builder) Step() *Step {
-	dst := make([]string, len(b.Env)+len(b.RunConfig.Env))
-	copy(dst, b.Env)
+	argsMap := make(map[string]string)
+	for _, argsVal := range b.Arguments() {
+		val := strings.SplitN(argsVal, "=", 2)
+		if len(val) > 1 {
+			argsMap[val[0]] = val[1]
+		}
+	}
+
+	userArgs := makeUserArgs(b.Env, argsMap) 
+	dst := make([]string, len(userArgs)+len(b.RunConfig.Env))
+	copy(dst, userArgs)
 	dst = append(dst, b.RunConfig.Env...)
-	dst = append(dst, b.Arguments()...)
+
 	return &Step{Env: dst}
 }
 

--- a/vendor/github.com/openshift/imagebuilder/dispatchers.go
+++ b/vendor/github.com/openshift/imagebuilder/dispatchers.go
@@ -153,8 +153,9 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	var chown string
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
+	userArgs := makeUserArgs(b.Env, b.Args)
 	for _, a := range flagArgs {
-		arg, err := ProcessWord(a, b.Env)
+		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
 			return err
 		}
@@ -181,8 +182,9 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
 	var chown string
 	var from string
+	userArgs := makeUserArgs(b.Env, b.Args)
 	for _, a := range flagArgs {
-		arg, err := ProcessWord(a, b.Env)
+		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
+++ b/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.8.1
-%{!?version: %global version 1.1-dev}
+%{!?version: %global version 1.1.6}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/vendor/github.com/openshift/imagebuilder/internals.go
+++ b/vendor/github.com/openshift/imagebuilder/internals.go
@@ -92,3 +92,28 @@ func parseOptInterval(f *flag.Flag) (time.Duration, error) {
 	}
 	return d, nil
 }
+
+// makeUserArgs - Package the variables from the Dockerfile defined by
+// the ENV aand the ARG statements into one slice so the values
+// defined by both can later be evaluated when resolving variables
+// such as ${MY_USER}.  If the variable is defined by both ARG and ENV
+// don't include the definition of the ARG variable.
+func makeUserArgs(bEnv []string, bArgs map[string]string) (userArgs []string) {
+
+	userArgs = bEnv
+	envMap := make(map[string]string)
+	for _, envVal := range bEnv {
+		val := strings.SplitN(envVal, "=", 2)
+		if len(val) > 1 {
+			envMap[val[0]] = val[1]
+		}
+	}
+
+	for key, value := range bArgs {
+		if _, ok := envMap[key]; ok {
+			continue
+		}
+		userArgs = append(userArgs, key+"="+value)
+	}
+	return userArgs
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -376,7 +376,7 @@ github.com/openshift/client-go/build/clientset/versioned/fake
 github.com/openshift/client-go/build/clientset/versioned/scheme
 github.com/openshift/client-go/build/clientset/versioned/typed/build/v1
 github.com/openshift/client-go/build/clientset/versioned/typed/build/v1/fake
-# github.com/openshift/imagebuilder v1.1.4
+# github.com/openshift/imagebuilder v1.1.6
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerfile/command
 github.com/openshift/imagebuilder/dockerfile/parser


### PR DESCRIPTION
Update imagebuilder from v1.1.4 to v1.1.6 to pick up additional fixes for expanding references to ARG values when processing instructions.