### PR TITLE
Bug 1826183: Run update-ca-trust if CA is non-empty

### DIFF
--- a/imagecontent/bin/entrypoint.sh
+++ b/imagecontent/bin/entrypoint.sh
@@ -2,7 +2,7 @@
 
 clusterCA="/var/run/configs/openshift.io/pki/tls-ca-bundle.pem"
 
-if [ -e "$clusterCA" ]; then
+if [ -s "$clusterCA" ]; then
     echo "Adding cluster TLS certificate authority to trust store"
     cp -f "$clusterCA" /etc/pki/ca-trust/source/anchors/cluster-ca-bundle.pem
     update-ca-trust extract


### PR DESCRIPTION
When openshift-builder starts, only run `update-ca-trust extract` if the mounted CA is non-empty.