### PR TITLE
Bug 1884610: Upgrade buildah to v1.16.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
-	github.com/containers/buildah v1.16.0
+	github.com/containers/buildah v1.16.4
 	github.com/containers/common v0.21.0
 	github.com/containers/image/v5 v5.5.2
 	github.com/containers/storage v1.23.3

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,10 @@ github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784 h1:rqUVL
 github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/containers/buildah v1.16.0 h1:/+18OBSgQ76oNwRnICkmzuOSyaWVDm/02/CvPoyEtvI=
-github.com/containers/buildah v1.16.0/go.mod h1:i1XqXgpCROnfcq4oNtfrFEk7UzNDxLJ/PZ+CnPyoIq8=
+github.com/containers/buildah v1.16.3 h1:GWQpoRvj9NKT/yUDH9NVI8IBNay6Q21Xw9iY4tuOJzc=
+github.com/containers/buildah v1.16.3/go.mod h1:i1XqXgpCROnfcq4oNtfrFEk7UzNDxLJ/PZ+CnPyoIq8=
+github.com/containers/buildah v1.16.4 h1:bxthp2FoGcpc2O/RyvbGUAZoefmc5hRBqWQi3BjRu7w=
+github.com/containers/buildah v1.16.4/go.mod h1:i1XqXgpCROnfcq4oNtfrFEk7UzNDxLJ/PZ+CnPyoIq8=
 github.com/containers/common v0.21.0 h1:v2U9MrGw0vMgefQf0/uJYBsSnengxLbSORYqhCVEBs0=
 github.com/containers/common v0.21.0/go.mod h1:8w8SVwc+P2p1MOnRMbSKNWXt1Iwd2bKFu2LLZx55DTM=
 github.com/containers/image/v5 v5.0.0/go.mod h1:MgiLzCfIeo8lrHi+4Lb8HP+rh513sm0Mlk6RrhjFOLY=

--- a/vendor/github.com/containers/buildah/.cirrus.yml
+++ b/vendor/github.com/containers/buildah/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "master"
+    DEST_BRANCH: "release-1.16"
     GOPATH: "/var/tmp/go"
     GOSRC: "${GOPATH}/src/github.com/containers/buildah"
     # Overrides default location (/tmp/cirrus) for repo clone

--- a/vendor/github.com/containers/buildah/.golangci.yml
+++ b/vendor/github.com/containers/buildah/.golangci.yml
@@ -7,38 +7,26 @@ run:
   # Don't exceed number of threads available when running under CI
   concurrency: 4
 linters:
-  disable-all: true
-  enable:
-    - bodyclose
+  enable-all: true
+  disable:
+    # All these break for one reason or another
     - deadcode
     - depguard
     - dupl
     - errcheck
-    - gofmt
-    - goimports
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
     - golint
-    # Broken? Unpredictably dies w/o any error well before deadline/timeout expires
-    # - gosimple
-    - govet
-    - ineffassign
-    - interfacer
-    - misspell
-    - nakedret
-    - staticcheck
+    - gosec
+    - gosimple
+    - lll
+    - maligned
+    - prealloc
+    - scopelint
     - structcheck
-    - stylecheck
     - typecheck
     - unconvert
-    - unparam
-    - unused
     - varcheck
-    # - gochecknoglobals
-    # - gochecknoinits
-    # - goconst
-    # - gocritic
-    # - gocyclo
-    # - gosec
-    # - lll
-    # - maligned
-    # - prealloc
-    # - scopelint

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 # Changelog
 
+## v1.16.4 (2020-10-01)
+    ADD: only expand archives at the right time
+
+## v1.16.3 (2020-09-30)
+    Lint: Use same linters as podman
+    add: preserve ownerships and permissions on ADDed archives
+    chroot: fix handling of errno seccomp rules
+    git-validation.sh: set the base for comparison to v1.16.0
+    chroot: create bind mount targets 0755 instead of 0700
+
+## v1.16.2 (2020-09-21)
+    Add(): fix handling of relative paths with no ContextDir
+
+## v1.16.1 (2020-09-10)
+    CI: use release-1.16 as the basis for validation tests
+    copier.Get(): hard link targets shouldn't be relative paths
+
 ## v1.16.0 (2020-09-03)
     fix build on 32bit arches
     containerImageRef.NewImageSource(): don't always force timestamps

--- a/vendor/github.com/containers/buildah/buildah.go
+++ b/vendor/github.com/containers/buildah/buildah.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.16.0"
+	Version = "1.16.4"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,20 @@
+- Changelog for v1.16.4 (2020-10-01)
+  * ADD: only expand archives at the right time
+
+- Changelog for v1.16.3 (2020-09-30)
+  * Lint: Use same linters as podman
+  * add: preserve ownerships and permissions on ADDed archives
+  * chroot: fix handling of errno seccomp rules
+  * git-validation.sh: set the base for comparison to v1.16.0
+  * chroot: create bind mount targets 0755 instead of 0700
+
+- Changelog for v1.16.2 (2020-09-21)
+  * Add(): fix handling of relative paths with no ContextDir
+
+- Changelog for v1.16.1 (2020-09-10)
+  * CI: use release-1.16 as the basis for validation tests
+  * copier.Get(): hard link targets shouldn't be relative paths
+
 - Changelog for v1.16.0 (2020-09-03)
   * fix build on 32bit arches
   * containerImageRef.NewImageSource(): don't always force timestamps

--- a/vendor/github.com/containers/buildah/chroot/run.go
+++ b/vendor/github.com/containers/buildah/chroot/run.go
@@ -1047,7 +1047,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subDev := filepath.Join(spec.Root.Path, "/dev")
 	if err := unix.Mount("/dev", subDev, "bind", devFlags, ""); err != nil {
 		if os.IsNotExist(err) {
-			err = os.Mkdir(subDev, 0700)
+			err = os.Mkdir(subDev, 0755)
 			if err == nil {
 				err = unix.Mount("/dev", subDev, "bind", devFlags, "")
 			}
@@ -1071,7 +1071,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subProc := filepath.Join(spec.Root.Path, "/proc")
 	if err := unix.Mount("/proc", subProc, "bind", procFlags, ""); err != nil {
 		if os.IsNotExist(err) {
-			err = os.Mkdir(subProc, 0700)
+			err = os.Mkdir(subProc, 0755)
 			if err == nil {
 				err = unix.Mount("/proc", subProc, "bind", procFlags, "")
 			}
@@ -1086,7 +1086,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subSys := filepath.Join(spec.Root.Path, "/sys")
 	if err := unix.Mount("/sys", subSys, "bind", sysFlags, ""); err != nil {
 		if os.IsNotExist(err) {
-			err = os.Mkdir(subSys, 0700)
+			err = os.Mkdir(subSys, 0755)
 			if err == nil {
 				err = unix.Mount("/sys", subSys, "bind", sysFlags, "")
 			}
@@ -1163,15 +1163,15 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			}
 			// The target isn't there yet, so create it.
 			if srcinfo.IsDir() {
-				if err = os.MkdirAll(target, 0111); err != nil {
+				if err = os.MkdirAll(target, 0755); err != nil {
 					return undoBinds, errors.Wrapf(err, "error creating mountpoint %q in mount namespace", target)
 				}
 			} else {
-				if err = os.MkdirAll(filepath.Dir(target), 0111); err != nil {
+				if err = os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 					return undoBinds, errors.Wrapf(err, "error ensuring parent of mountpoint %q (%q) is present in mount namespace", target, filepath.Dir(target))
 				}
 				var file *os.File
-				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0); err != nil {
+				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0755); err != nil {
 					return undoBinds, errors.Wrapf(err, "error creating mountpoint %q in mount namespace", target)
 				}
 				file.Close()

--- a/vendor/github.com/containers/buildah/copier/copier.go
+++ b/vendor/github.com/containers/buildah/copier/copier.go
@@ -222,6 +222,10 @@ type GetOptions struct {
 	UIDMap, GIDMap     []idtools.IDMap // map from hostIDs to containerIDs in the output archive
 	Excludes           []string        // contents to pretend don't exist, using the OS-specific path separator
 	ExpandArchives     bool            // extract the contents of named items that are archives
+	ChownDirs          *idtools.IDPair // set ownership on directories. no effect on archives being extracted
+	ChmodDirs          *os.FileMode    // set permissions on directories. no effect on archives being extracted
+	ChownFiles         *idtools.IDPair // set ownership of files. no effect on archives being extracted
+	ChmodFiles         *os.FileMode    // set permissions on files. no effect on archives being extracted
 	StripSetuidBit     bool            // strip the setuid bit off of items being copied. no effect on archives being extracted
 	StripSetgidBit     bool            // strip the setgid bit off of items being copied. no effect on archives being extracted
 	StripStickyBit     bool            // strip the sticky bit off of items being copied. no effect on archives being extracted
@@ -265,6 +269,8 @@ func Get(root string, directory string, options GetOptions, globs []string, bulk
 // PutOptions controls parts of Put()'s behavior.
 type PutOptions struct {
 	UIDMap, GIDMap    []idtools.IDMap // map from containerIDs to hostIDs when writing contents to disk
+	DefaultDirOwner   *idtools.IDPair // set ownership of implicitly-created directories, default is ChownDirs, or 0:0 if ChownDirs not set
+	DefaultDirMode    *os.FileMode    // set permissions on implicitly-created directories, default is ChmodDirs, or 0755 if ChmodDirs not set
 	ChownDirs         *idtools.IDPair // set ownership of newly-created directories
 	ChmodDirs         *os.FileMode    // set permissions on newly-created directories
 	ChownFiles        *idtools.IDPair // set ownership of newly-created files
@@ -1032,6 +1038,9 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 			}
 			// evaluate excludes relative to the root directory
 			if info.Mode().IsDir() {
+				// we don't expand any of the contents that are archives
+				options := req.GetOptions
+				options.ExpandArchives = false
 				walkfn := func(path string, info os.FileInfo, err error) error {
 					// compute the path of this item
 					// relative to the top-level directory,
@@ -1073,7 +1082,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 						symlinkTarget = target
 					}
 					// add the item to the outgoing tar stream
-					return copierHandlerGetOne(info, symlinkTarget, rel, path, req.GetOptions, tw, hardlinkChecker, idMappings)
+					return copierHandlerGetOne(info, symlinkTarget, rel, path, options, tw, hardlinkChecker, idMappings)
 				}
 				// walk the directory tree, checking/adding items individually
 				if err := filepath.Walk(item, walkfn); err != nil {
@@ -1178,14 +1187,11 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		target := hardlinkChecker.Check(srcfi)
 		if target != "" {
 			hdr.Typeflag = tar.TypeLink
-			if filepath.Dir(filepath.Clean(string(os.PathSeparator)+name)) == filepath.Dir(target) {
-				target = filepath.Base(target)
-			}
 			hdr.Linkname = filepath.ToSlash(target)
 			hdr.Size = 0
 		} else {
 			// note the device/inode pair for this file
-			hardlinkChecker.Add(srcfi, string(os.PathSeparator)+name)
+			hardlinkChecker.Add(srcfi, name)
 		}
 	}
 	// map the ownership for the archive
@@ -1194,6 +1200,22 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		hdr.Uid, hdr.Gid, err = idMappings.ToContainer(hostPair)
 		if err != nil {
 			return errors.Wrapf(err, "error mapping host filesystem owners %#v to container filesystem owners", hostPair)
+		}
+	}
+	// force ownership and/or permissions, if requested
+	if hdr.Typeflag == tar.TypeDir {
+		if options.ChownDirs != nil {
+			hdr.Uid, hdr.Gid = options.ChownDirs.UID, options.ChownDirs.GID
+		}
+		if options.ChmodDirs != nil {
+			hdr.Mode = int64(*options.ChmodDirs)
+		}
+	} else {
+		if options.ChownFiles != nil {
+			hdr.Uid, hdr.Gid = options.ChownFiles.UID, options.ChownFiles.GID
+		}
+		if options.ChmodFiles != nil {
+			hdr.Mode = int64(*options.ChmodFiles)
 		}
 	}
 	// output the header
@@ -1223,13 +1245,20 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 	errorResponse := func(fmtspec string, args ...interface{}) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Put: putResponse{}}, nil, nil
 	}
-	dirUID, dirGID := 0, 0
+	dirUID, dirGID, defaultDirUID, defaultDirGID := 0, 0, 0, 0
 	if req.PutOptions.ChownDirs != nil {
 		dirUID, dirGID = req.PutOptions.ChownDirs.UID, req.PutOptions.ChownDirs.GID
+		defaultDirUID, defaultDirGID = dirUID, dirGID
 	}
-	dirMode := os.FileMode(0755)
+	defaultDirMode := os.FileMode(0755)
 	if req.PutOptions.ChmodDirs != nil {
-		dirMode = *req.PutOptions.ChmodDirs
+		defaultDirMode = *req.PutOptions.ChmodDirs
+	}
+	if req.PutOptions.DefaultDirOwner != nil {
+		defaultDirUID, defaultDirGID = req.PutOptions.DefaultDirOwner.UID, req.PutOptions.DefaultDirOwner.GID
+	}
+	if req.PutOptions.DefaultDirMode != nil {
+		defaultDirMode = *req.PutOptions.DefaultDirMode
 	}
 	var fileUID, fileGID *int
 	if req.PutOptions.ChownFiles != nil {
@@ -1261,11 +1290,11 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			subdir = filepath.Join(subdir, component)
 			path := filepath.Join(req.Root, subdir)
 			if err := os.Mkdir(path, 0700); err == nil {
-				if err = lchown(path, dirUID, dirGID); err != nil {
-					return errors.Wrapf(err, "copier: put: error setting owner of %q to %d:%d", path, dirUID, dirGID)
+				if err = lchown(path, defaultDirUID, defaultDirGID); err != nil {
+					return errors.Wrapf(err, "copier: put: error setting owner of %q to %d:%d", path, defaultDirUID, defaultDirGID)
 				}
-				if err = os.Chmod(path, dirMode); err != nil {
-					return errors.Wrapf(err, "copier: put: error setting permissions on %q to 0%o", path, dirMode)
+				if err = os.Chmod(path, defaultDirMode); err != nil {
+					return errors.Wrapf(err, "copier: put: error setting permissions on %q to 0%o", path, defaultDirMode)
 				}
 			} else {
 				if !os.IsExist(err) {
@@ -1375,14 +1404,8 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				}
 			case tar.TypeLink:
 				var linkTarget string
-				if filepath.IsAbs(filepath.FromSlash(hdr.Linkname)) || looksLikeAbs(filepath.FromSlash(hdr.Linkname)) {
-					if linkTarget, err = resolvePath(targetDirectory, filepath.Join(req.Root, filepath.FromSlash(hdr.Linkname)), nil); err != nil {
-						return errors.Errorf("error resolving hardlink target path %q under root %q", hdr.Linkname, req.Root)
-					}
-				} else {
-					if linkTarget, err = resolvePath(targetDirectory, filepath.Join(targetDirectory, filepath.Dir(filepath.FromSlash(hdr.Name)), filepath.FromSlash(hdr.Linkname)), nil); err != nil {
-						return errors.Errorf("error resolving hardlink target path %q under root %q in directory %q", hdr.Linkname, req.Root, filepath.Dir(filepath.FromSlash(hdr.Name)))
-					}
+				if linkTarget, err = resolvePath(targetDirectory, filepath.Join(req.Root, filepath.FromSlash(hdr.Linkname)), nil); err != nil {
+					return errors.Errorf("error resolving hardlink target path %q under root %q", hdr.Linkname, req.Root)
 				}
 				if err = os.Link(linkTarget, path); err != nil && os.IsExist(err) {
 					if err = os.Remove(path); err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/buildah v1.16.0
+# github.com/containers/buildah v1.16.4
 github.com/containers/buildah
 github.com/containers/buildah/bind
 github.com/containers/buildah/chroot


### PR DESCRIPTION
Bump github.com/containers/buildah from v1.16.0 to v1.16.4, mainly to pick up https://github.com/containers/buildah/pull/2660 and https://github.com/containers/buildah/pull/2668, but also pulling in https://github.com/containers/buildah/pull/2653 to avoid a potential problem that could occur if/when the seccomp.json in the builder image is updated to start using "errno" actions.