### PR TITLE
Bug 1891759: Do not mount /etc/pki/ca-trust in builds

### DIFF
--- a/imagecontent/etc/containers/mounts.conf
+++ b/imagecontent/etc/containers/mounts.conf
@@ -1,2 +1,1 @@
 /run/secrets:/run/secrets
-/etc/pki/ca-trust:/etc/pki/ca-trust


### PR DESCRIPTION
`/etc/pki/ca-trust` contains the system trust stores for a wide array of
applications. Making this a mount point in buildah causes the original
data in the base image to overlayed by the contents in the build container.
As a result, `/etc/pki/ca-trust` cannot be altered unless another layer is
added to the image being built via a COPY or ADD instruction.

This will revert the mount of `/etc/pki/ca-trust`, thereby removing the ability
of builds to use the cluster trust bundle. This capability will be restored in
a future OpenShift release as an opt-in enhancement.