### PR TITLE
Move dev Dockerfile to Fedora 33

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,12 +1,12 @@
-FROM docker.io/library/centos:7
+FROM registry.fedoraproject.org/fedora:33
 LABEL io.k8s.display-name="OpenShift Origin Builder" \
       io.k8s.description="This is a component of OpenShift Origin and is responsible for executing image builds." \
       io.openshift.tags="openshift,builder"
 
 # TODO: Add fuse-overlayfs once we build off of RHEL-8 UBI
 RUN INSTALL_PKGS=" \
-      bind-utils bsdtar findutils git hostname lsof socat \
-      sysvinit-tools tar tree util-linux wget which \
+      bind-utils bsdtar findutils fuse-overlayfs git hostname lsof \
+      procps-ng socat tar tree util-linux wget which \
       " && \
     yum install -y --setopt=skip_missing_names_on_install=False ${INSTALL_PKGS} && \
     yum clean all


### PR DESCRIPTION
openshift/builder is now RHEL8 based. Updating Dockerfile-dev to use
Fedora 33 as the base image, as this is publicly accessible and has the
same packages available that CI/OSBS does. Note - ubi8 not used because
tree is not available in the free, public RPM repositories.