### PR TITLE
Bug 1907407: Print buildah version

### DIFF
--- a/cmd/builder.go
+++ b/cmd/builder.go
@@ -49,13 +49,14 @@ var (
 
 // NewCmdVersion provides a shim around version for
 // non-client packages that require version information
-func NewCmdVersion(fullName string, versionInfo k8sversion.Info, out io.Writer) *cobra.Command {
+func NewCmdVersion(fullName string, versionInfo k8sversion.Info, buildahVersion string, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Display version",
 		Long:  "Display version",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(out, "%s %v\n", fullName, versionInfo)
+			fmt.Fprintf(out, "Buildah version %s\n", buildahVersion)
 		},
 	}
 
@@ -74,7 +75,7 @@ func NewCommandS2IBuilder(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(NewCmdVersion(name, version.Get(), os.Stdout))
+	cmd.AddCommand(NewCmdVersion(name, version.Get(), version.BuildahVersion(), os.Stdout))
 	return cmd
 }
 
@@ -89,7 +90,7 @@ func NewCommandDockerBuilder(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdVersion(name, version.Get(), os.Stdout))
+	cmd.AddCommand(NewCmdVersion(name, version.Get(), version.BuildahVersion(), os.Stdout))
 	return cmd
 }
 
@@ -105,7 +106,7 @@ func NewCommandGitClone(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdVersion(name, version.Get(), os.Stdout))
+	cmd.AddCommand(NewCmdVersion(name, version.Get(), version.BuildahVersion(), os.Stdout))
 	return cmd
 }
 
@@ -119,7 +120,7 @@ func NewCommandManageDockerfile(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdVersion(name, version.Get(), os.Stdout))
+	cmd.AddCommand(NewCmdVersion(name, version.Get(), version.BuildahVersion(), os.Stdout))
 	return cmd
 }
 
@@ -133,6 +134,6 @@ func NewCommandExtractImageContent(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(NewCmdVersion(name, version.Get(), os.Stdout))
+	cmd.AddCommand(NewCmdVersion(name, version.Get(), version.BuildahVersion(), os.Stdout))
 	return cmd
 }

--- a/hack/lib/build/version.sh
+++ b/hack/lib/build/version.sh
@@ -17,6 +17,7 @@ function os::build::version::get_vars() {
 		os::log::warning "No version file at ${OS_VERSION_FILE}, falling back to git versions"
 	fi
 	os::build::version::git_vars
+	os::build::version::buildah_vars
 }
 readonly -f os::build::version::get_vars
 
@@ -72,6 +73,14 @@ function os::build::version::git_vars() {
 }
 readonly -f os::build::version::git_vars
 
+function os::build::version::buildah_vars() {
+	if [[ -n "${OS_BUILDAH_VERSION-}" ]]; then
+		return 0
+	fi
+	OS_BUILDAH_VERSION=$(go list -mod=mod -m -f '{{.Version}}' github.com/containers/buildah)
+}
+readonly -f os::build::version::buildah_vars
+
 # os::build::version::save_vars saves the environment flags to $1
 function os::build::version::save_vars() {
 	cat <<EOF
@@ -105,6 +114,7 @@ function os::build::ldflags() {
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.versionFromGit" "${OS_GIT_VERSION}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.commitFromGit" "${OS_GIT_COMMIT}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.buildDate" "${buildDate}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.buildahVersion" "${OS_BUILDAH_VERSION}"))
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"

--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -480,4 +480,5 @@ func RunExtractImageContent(out io.Writer) error {
 // logVersion logs the version of openshift-builder.
 func logVersion() {
 	log.V(5).Infof("openshift-builder %v", version.Get())
+	log.V(5).Infof("Powered by buildah %s", version.BuildahVersion())
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,8 @@ var (
 	minorFromGit string
 	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 	buildDate string
+	// buildahVersion reports the version of buildah vendored into openshift/builder
+	buildahVersion string
 )
 
 // Get returns the overall codebase version. It's for detecting
@@ -29,4 +31,9 @@ func Get() version.Info {
 		GitVersion: versionFromGit,
 		BuildDate:  buildDate,
 	}
+}
+
+// BuildahVersion returns the version of buildah vendored in.
+func BuildahVersion() string {
+	return buildahVersion
 }


### PR DESCRIPTION
- Determine buildah version vendored in from go modules
- Add buildah version as an ldflag
- Print buildah version as the output to all `version` commands
- Log buildah version with -v=5 or higher