### PR TITLE
Bug 1916897: more automount of cluster trust bundle reverts; no longer automount /run/secrets

### DIFF
--- a/imagecontent/etc/containers/mounts.conf
+++ b/imagecontent/etc/containers/mounts.conf
@@ -1,1 +1,0 @@
-/run/secrets:/run/secrets


### PR DESCRIPTION
possible fix for https://bugzilla.redhat.com/show_bug.cgi?id=1916897

history of 4.6.0 bug fix that introduced regression that is being reverted noted in above BZ