### PR TITLE
Bug 1918153: incorrect escaping of HTML symbols in envars

### DIFF
--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -380,7 +380,7 @@ func TestDockerfilePath(t *testing.T) {
 		"\"OPENSHIFT_BUILD_SOURCE\"=\"http://github.com/openshift/origin.git\"",
 		"\"OPENSHIFT_BUILD_COMMIT\"=\"commitid\"",
 		// expected labels
-		"\"io.openshift.build.commit.author\"=\"test user \\u003ctest@email.com\\u003e\"",
+		"\"io.openshift.build.commit.author\"=\"test user <test@email.com>\"",
 		"\"io.openshift.build.commit.date\"=\"date\"",
 		"\"io.openshift.build.commit.id\"=\"commitid\"",
 		"\"io.openshift.build.commit.ref\"=\"ref\"",

--- a/pkg/build/builder/util/dockerfile/instructions.go
+++ b/pkg/build/builder/util/dockerfile/instructions.go
@@ -1,8 +1,8 @@
 package dockerfile
 
 import (
-	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/openshift/imagebuilder/dockerfile/command"
@@ -38,23 +38,17 @@ func Run(cmd string) (string, error) {
 	return unquotedArgsInstruction(command.Run, cmd)
 }
 
-// keyValueInstruction builds a Dockerfile instruction from the mapping m. Keys
-// and values are serialized as JSON strings to ensure compatibility with the
-// Dockerfile parser. Syntax:
+// keyValueInstruction builds a Dockerfile instruction from the mapping m. Keys and
+// values are quoted and non-printable characters escaped to ensure compatibility
+// with the Dockerfile parser. Syntax:
 //   COMMAND "KEY"="VALUE" "may"="contain spaces"
 func keyValueInstruction(cmd string, m []KeyValue) (string, error) {
 	s := []string{strings.ToUpper(cmd)}
 	for _, kv := range m {
-		// Marshal kv.Key and kv.Value as JSON strings to cover cases
-		// like when the values contain spaces or special characters.
-		k, err := json.Marshal(kv.Key)
-		if err != nil {
-			return "", err
-		}
-		v, err := json.Marshal(kv.Value)
-		if err != nil {
-			return "", err
-		}
+		// Process with 'strconv.Quote' function to allow whitespaces
+		// and escape non-printable and control characters
+		k := strconv.Quote(kv.Key)
+		v := strconv.Quote(kv.Value)
 		s = append(s, fmt.Sprintf("%s=%s", k, v))
 	}
 	return strings.Join(s, " "), nil

--- a/pkg/build/builder/util/dockerfile/instructions_test.go
+++ b/pkg/build/builder/util/dockerfile/instructions_test.go
@@ -65,7 +65,18 @@ func TestKeyValueInstructions(t *testing.T) {
 			in: []KeyValue{
 				{"☃", "'\" \\ / \b \f \n \r \t \x00"},
 			},
-			want: `"☃"="'\" \\ / \u0008 \u000c \n \r \t \u0000"`,
+			want: `"☃"="'\" \\ / \b \f \n \r \t \x00"`,
+		},
+		{
+			// We should verify that HTML symbols < > & are not escaped,
+			// as it is perfectly fine and expected for them to be used
+			// in Dockerfile
+			in: []KeyValue{
+				{"URL", "https://domain.name/key1=val1&key2=val2"},
+				{"NAME", "Person Name <person.name@domain.name>"},
+			},
+			want: `"URL"="https://domain.name/key1=val1&key2=val2"` +
+				` "NAME"="Person Name <person.name@domain.name>"`,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
When building from source using docker strategy, keys and values for environment variables from BuildConfig and labels have been marshalled to json strings to put them in quotes and do escaping.
Problem was, this marshalling also escapes HTML symbols `<>&`, which should be allowed for environment variables and labels.
Solution is to process values with `strconv.Quote` function in order to escape only non-printable and control characters.

With the BuildConfig provided in Bugzilla, and my changes I get this result:

```
wyvie@irum-mac ~/go/src/github.com/openshift/builder (fix-build-envars-character-escaping*) $ oc logs -f bc/docker-build
...
STEP 1: FROM quay.io/generic/rhel7:latest
STEP 2: ENV "IncorrectURLFromENV"="http://abc.com/q?key1=value1&key2=value2"
...
STEP 5: ENV CorrectURLFromDockerFile='https://abc123.com/q?key1=value1&key2=value2'
--> b74c4ad1b71
...
STEP 10: LABEL "io.openshift.build.commit.author"="Rejeeb <54980000+rejeeb786@users.noreply.github.com>" "io.openshift.build.commit.date"="Wed Jan 20 07:34:30 2021 +0530" "io.openshift.build.commit.id"="b83aaf78858b7a8e970a52a07e06dfb3bb7e7ecc" "io.openshift.build.commit.message"="Update Dockerfile" "io.openshift.build.commit.ref"="main" "io.openshift.build.name"="docker-[build-1](https://issues.redhat.com/browse/build-1)" "io.openshift.build.namespace"="testing" "io.openshift.build.source-context-dir"="/" "io.openshift.build.source-location"="https://github.com/rejeeb786/test.git"
...
```