### PR TITLE
Bug 1921965: narrow scope of rhsm transient bind mount; originate it from tmp dir for cases where data can persist

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -20,6 +18,7 @@ import (
 	"github.com/openshift/builder/pkg/build/builder"
 	"github.com/openshift/builder/pkg/version"
 	"github.com/openshift/library-go/pkg/serviceability"
+	s2ifs "github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 func main() {
@@ -50,14 +49,15 @@ func main() {
 
 	clusterCASrc := fmt.Sprintf("%s/ca.crt", builder.SecretCertsMountPath)
 	clusterCADst := fmt.Sprintf("%s/cluster.crt", tlsCertRoot)
-	err := CopyFileIfExists(clusterCASrc, clusterCADst)
+	fs := s2ifs.NewFileSystem()
+	err := fs.Copy(clusterCASrc, clusterCADst, map[string]string{})
 	if err != nil {
 		fmt.Printf("Error setting up cluster CA cert: %v", err)
 		os.Exit(1)
 	}
 
 	runtimeCASrc := fmt.Sprintf("%s/certs.d", builder.ConfigMapCertsMountPath)
-	err = CopyDirIfExists(runtimeCASrc, runtimeCertRoot)
+	err = fs.CopyContents(runtimeCASrc, runtimeCertRoot, map[string]string{})
 	if err != nil {
 		fmt.Printf("Error setting up service CA cert: %v", err)
 		os.Exit(1)
@@ -68,60 +68,6 @@ func main() {
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}
-}
-
-// CopyDirIfExists recursively copies a directory to the destination path.
-// If the source directory does not exist, no error is returned.
-// If the destination directory exists, any contents with matching file names
-// will be overwritten.
-func CopyDirIfExists(src, dst string) error {
-	srcInfo, err := os.Stat(src)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err = os.MkdirAll(dst, srcInfo.Mode()); err != nil {
-		return err
-	}
-	dirInfo, err := ioutil.ReadDir(src)
-	for _, info := range dirInfo {
-		srcPath := filepath.Join(src, info.Name())
-		dstPath := filepath.Join(dst, info.Name())
-		if info.IsDir() {
-			err = CopyDirIfExists(srcPath, dstPath)
-		} else {
-			err = CopyFileIfExists(srcPath, dstPath)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// CopyFileIfExists copies the source file to the given destination, if the source file exists.
-// If the destination file exists, it will be overwritten and will not copy file attributes.
-func CopyFileIfExists(src, dst string) error {
-	_, err := os.Stat(src)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	if err != nil {
-		return err
-	}
-	return out.Close()
 }
 
 // CommandFor returns the appropriate command for this base name,

--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -5,6 +5,7 @@ package builder
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -26,6 +27,7 @@ import (
 	buildapiv1 "github.com/openshift/api/build/v1"
 	"github.com/openshift/builder/pkg/build/builder/cmd/dockercfg"
 	builderutil "github.com/openshift/builder/pkg/build/builder/util"
+	s2ifs "github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 // The build controller doesn't expect the CAP_ prefix to be used in the
@@ -131,10 +133,22 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 	}
 
 	var transientMounts []string
-	if st, err := os.Stat("/run/secrets"); err == nil && st.IsDir() {
-		// Add a bind of /run/secrets, to pass along anything that the
-		// runtime mounted from the node into our /run/secrets.
-		transientMounts = append(transientMounts, "/run/secrets:/run/secrets:ro,nodev,noexec,nosuid")
+	if st, err := os.Stat("/run/secrets/rhsm"); err == nil && st.IsDir() {
+		// Add a bind of /run/secrets/rhsm, to pass along anything that the
+		// runtime mounted from the node into our /run/secrets/rhsm.
+		log.V(0).Infof("Adding transient rw bind mount for /run/secrets/rhsm")
+		tmpDir, err := ioutil.TempDir("/tmp", "rhsm-copy")
+		if err != nil {
+			log.V(0).Infof("Error creating tmpdir to set up /run/secrets/rhsm in build container: %s", err.Error())
+			return err
+		}
+		fs := s2ifs.NewFileSystem()
+		err = fs.CopyContents("/run/secrets/rhsm", tmpDir, map[string]string{})
+		if err != nil {
+			log.V(0).Infof("Error copying /run/secrets/rhsm to tmpdir %s: %s", tmpDir, err.Error())
+			return err
+		}
+		transientMounts = append(transientMounts, fmt.Sprintf("%s:/run/secrets/rhsm:rw,nodev,noexec,nosuid", tmpDir))
 	}
 
 	// Use a profile provided in the image instead of the default provided


### PR DESCRIPTION
/assign @adambkaplan 
/assign @bparees ( for bz labels )

needed a manual cherrypick for 4.4 as well to get things to compile