### PR TITLE
Bug 1937535: retry image pulls during builds

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -295,6 +295,8 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 		ForceRmIntermediateCtrs: true,
 		BlobDirectory:           blobCacheDirectory,
 		DropCapabilities:        dropCapabilities(),
+		MaxPullPushRetries:      DefaultPushOrPullRetryCount,
+		PullPushRetryDelay:      DefaultPushOrPullRetryDelay,
 	}
 
 	_, _, err := imagebuildah.BuildDockerfiles(opts.Context, store, options, opts.Dockerfile)
@@ -574,7 +576,9 @@ func daemonlessRun(ctx context.Context, store storage.Store, isolation buildah.I
 			CgroupParent: createOpts.HostConfig.CgroupParent,
 			Ulimit:       daemonlessProcessLimits(),
 		},
-		BlobDirectory: blobCacheDirectory,
+		BlobDirectory:  blobCacheDirectory,
+		MaxPullRetries: DefaultPushOrPullRetryCount,
+		PullRetryDelay: DefaultPushOrPullRetryDelay,
 	}
 
 	builder, err := buildah.NewBuilder(ctx, store, builderOptions)
@@ -648,9 +652,11 @@ func (d *DaemonlessClient) RemoveImage(name string) error {
 
 func (d *DaemonlessClient) CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error) {
 	options := buildah.BuilderOptions{
-		FromImage:     opts.Config.Image,
-		Container:     opts.Name,
-		BlobDirectory: d.BlobCacheDirectory,
+		FromImage:      opts.Config.Image,
+		Container:      opts.Name,
+		BlobDirectory:  d.BlobCacheDirectory,
+		MaxPullRetries: DefaultPushOrPullRetryCount,
+		PullRetryDelay: DefaultPushOrPullRetryDelay,
 	}
 	builder, err := buildah.NewBuilder(opts.Context, d.Store, options)
 	if err != nil {

--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -448,6 +448,8 @@ func extractSourceFromImage(ctx context.Context, dockerClient DockerClient, stor
 		CommonBuildOpts: &buildah.CommonBuildOptions{
 			HTTPProxy: true,
 		},
+		MaxPullRetries: DefaultPushOrPullRetryCount,
+		PullRetryDelay: DefaultPushOrPullRetryDelay,
 	}
 
 	builder, err := buildah.NewBuilder(ctx, store, builderOptions)


### PR DESCRIPTION
Have the builder retry if it fails to pull an image, one which we didn't pre-pull ourselves, during the build.