### PR TITLE
Bug 1947164: Print "Successfully pushed" only if push succeeded

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -469,7 +469,9 @@ func pushDaemonlessImage(sc types.SystemContext, store storage.Store, imageName 
 			}
 		}
 	}
-	log.V(0).Infof("Successfully pushed %s", logName)
+	if err == nil {
+		log.V(0).Infof("Successfully pushed %s", logName)
+	}
 	return string(digest), err
 }
 


### PR DESCRIPTION
```
Pushing image image-registry.openshift-image-registry.svc:5000/foo/busybox:latest ...
Getting image source signatures
Successfully pushed image-registry.openshift-image-registry.svc:5000/foo/busybox:latest
Warning: Push failed, retrying in 5s ...
Getting image source signatures
Successfully pushed image-registry.openshift-image-registry.svc:5000/foo/busybox:latest
Warning: Push failed, retrying in 5s ...
Getting image source signatures
Successfully pushed image-registry.openshift-image-registry.svc:5000/foo/busybox:latest
Warning: Push failed, retrying in 5s ...
error: build error: Failed to push image: error copying layers and metadata from "containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.imagestore=/var/lib/shared]image-registry.openshift-image-registry.svc:5000/foo/busybox:latest" to "docker://image-registry.openshift-image-registry.svc:5000/foo/busybox:latest": Error trying to reuse blob sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4 at destination: error pinging docker registry image-registry.openshift-image-registry.svc:5000: Get "https://image-registry.openshift-image-registry.svc:5000/v2/": dial tcp: lookup image-registry.openshift-image-registry.svc on 172.30.0.10:53: no such host
```