### PR TITLE
Bug 1943614: add explict exit log after buildah pull image; tweak existing start log priot to buildah pull image call

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -160,7 +160,7 @@ func mergeNodeCredentialsDockerAuth(credsPath string) *docker.AuthConfigurations
 }
 
 func pullDaemonlessImage(sc types.SystemContext, store storage.Store, imageName string, searchPaths []string, blobCacheDirectory string) error {
-	log.V(0).Infof("Asked to pull fresh copy of %q.", imageName)
+	log.V(2).Infof("Attempting pull of image %q.", imageName)
 
 	if imageName == "" {
 		return fmt.Errorf("unable to pull using empty image name")
@@ -201,9 +201,13 @@ func pullDaemonlessImage(sc types.SystemContext, store storage.Store, imageName 
 		BlobDirectory: blobCacheDirectory,
 	}
 	_, err = buildah.Pull(context.TODO(), "docker://"+imageName, options)
-	log.V(0).Infof("Finished pulling image %s", imageName)
+	if err == nil {
+		log.V(2).Infof("Finished pulling image %q", imageName)
+	} else {
+		log.V(2).Infof("Error pulling image %q: %s", imageName, err.Error())
+	}
 	if err != nil && dockerConfigCredsErr != nil {
-		err = fmt.Errorf("%s; also, error processing dockerconfigjson: %s", err.Error(), dockerConfigCredsErr.Error())
+		err = fmt.Errorf("Error pulling image %q: %s; also, error processing dockerconfigjson: %s", imageName, err.Error(), dockerConfigCredsErr.Error())
 	}
 	return err
 }


### PR DESCRIPTION
Our CI / testplatform team are seeing inexplicably long delays when OpenShift Builds try to pull image content as input prior to building the image.

Some corresponding "end" messages to go with the "start" messages that already exist was deemed helpful in their diagnostic efforts. so they easily demarcate when the openshift/builder image calls out into the vendored buildah/containers code.

/assign @bparees 