### PR TITLE
Bug 1943726: add bracket logging on openshift/builder calls into buildah to assist test-platform team triage

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -152,7 +152,7 @@ func mergeNodeCredentialsDockerAuth(credsPath string) *docker.AuthConfigurations
 }
 
 func pullDaemonlessImage(sc types.SystemContext, store storage.Store, imageName string, searchPaths []string, blobCacheDirectory string) error {
-	log.V(2).Infof("Asked to pull fresh copy of %q.", imageName)
+	log.V(0).Infof("Asked to pull fresh copy of %q.", imageName)
 
 	if imageName == "" {
 		return fmt.Errorf("unable to pull using empty image name")
@@ -193,6 +193,7 @@ func pullDaemonlessImage(sc types.SystemContext, store storage.Store, imageName 
 		BlobDirectory: blobCacheDirectory,
 	}
 	_, err = buildah.Pull(context.TODO(), "docker://"+imageName, options)
+	log.V(0).Infof("Finished pulling image %s", imageName)
 	if err != nil && dockerConfigCredsErr != nil {
 		err = fmt.Errorf("%s; also, error processing dockerconfigjson: %s", err.Error(), dockerConfigCredsErr.Error())
 	}

--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -152,7 +152,7 @@ func mergeNodeCredentialsDockerAuth(credsPath string) *docker.AuthConfigurations
 }
 
 func pullDaemonlessImage(sc types.SystemContext, store storage.Store, imageName string, searchPaths []string, blobCacheDirectory string) error {
-	log.V(0).Infof("Asked to pull fresh copy of %q.", imageName)
+	log.V(2).Infof("Attempting pull of image %q.", imageName)
 
 	if imageName == "" {
 		return fmt.Errorf("unable to pull using empty image name")
@@ -193,9 +193,13 @@ func pullDaemonlessImage(sc types.SystemContext, store storage.Store, imageName 
 		BlobDirectory: blobCacheDirectory,
 	}
 	_, err = buildah.Pull(context.TODO(), "docker://"+imageName, options)
-	log.V(0).Infof("Finished pulling image %s", imageName)
+	if err == nil {
+		log.V(2).Infof("Finished pulling image %q", imageName)
+	} else {
+		log.V(2).Infof("Error pulling image %q: %s", imageName, err.Error())
+	}
 	if err != nil && dockerConfigCredsErr != nil {
-		err = fmt.Errorf("%s; also, error processing dockerconfigjson: %s", err.Error(), dockerConfigCredsErr.Error())
+		err = fmt.Errorf("Error pulling image %q: %s; also, error processing dockerconfigjson: %s", imageName, err.Error(), dockerConfigCredsErr.Error())
 	}
 	return err
 }


### PR DESCRIPTION
manual cherrypick of the 2 4.8 PRs / commits to get consensus on the start/end logging around calls from openshift/builder into the vendored buildah code when builds define `ImageSource` entries and we call buildah to execute the download/copy of those image refs

@stevekuznetsov and the testplatform team is trying to diagnose undo slowness of this function in the CI clusters
they have also already turned on V6 trace for builds in those clusters, but on their next 4.7.x upgrade of the CI clusters, they can get this logging too, as they indicated that would help them.

Ultimately, between build api team and @nalind we can help them pinpoint where the delays are occurring.

/assign @bparees 

i.e. this is the redo of the 4.7 PR I assigned to you, but then we agreed to close, yesterday