### PR TITLE
Bug 1946363: move entitlement related secrets back to mounts.conf

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,7 @@ github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHo
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -651,7 +652,7 @@ github.com/openshift/library-go v0.0.0-20201126123001-e59ac21aada3 h1:sk60hcNw2I
 github.com/openshift/library-go v0.0.0-20201126123001-e59ac21aada3/go.mod h1:KNfLGf4dIRJ+QB2aGy67AOy1k+DV783cMCuJf0d4Zik=
 github.com/openshift/moby-moby v1.4.2-0.20190308215630-da810a85109d h1:1LuQzDKgiXj1omPNDcY1E/mEOE/90jdobR+7WBfBQYA=
 github.com/openshift/moby-moby v1.4.2-0.20190308215630-da810a85109d/go.mod h1:LJM49W8fBVSj+rvcopJZu9mgH5Tx6HwLHySIYeGeu4k=
-github.com/openshift/source-to-image v1.3.0 h1:ZktIgJ85Vn0HOyHdS6uQOMXhmYwc5h76w/6LpnJ60L8=
+github.com/openshift/source-to-image v1.3.0 h1:YDEH0PY0sMaUNbpJAGnDZA94tkAD6qi1Rou8ycWRPRc=
 github.com/openshift/source-to-image v1.3.0/go.mod h1:HEWMBvkkwGoJo+CMxnfYJW6O52zc052D83XBUo1zFRw=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20171029140428-b1a47cfbdd75/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v0.0.0-20171003133519-1361b9cd60be/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/imagecontent/etc/containers/mounts.conf
+++ b/imagecontent/etc/containers/mounts.conf
@@ -1,0 +1,3 @@
+/run/secrets/rhsm:/run/secrets/rhsm
+/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement
+/run/secrets/redhat.repo:/run/secrets/redhat.repo


### PR DESCRIPTION
manual pick of https://github.com/openshift/builder/pull/240 required

among other things, I got this error running `make test`, `go mod tidy`, `go mod vendor` 

```
verifying github.com/openshift/source-to-image@v1.3.0: checksum mismatch
	downloaded: h1:YDEH0PY0sMaUNbpJAGnDZA94tkAD6qi1Rou8ycWRPRc=
	go.sum:     h1:ZktIgJ85Vn0HOyHdS6uQOMXhmYwc5h76w/6LpnJ60L8=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.

For more information, see 'go help module-auth'.
```

so there is a separate commit to fix `go.sum` and make the noted commands happy

/assign @adambkaplan 