### PR TITLE
Bug 1971332: add clarifying comment on lack of ssh:// in url not affecting ssh private key setup

### DIFF
--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -208,6 +208,8 @@ func (c *builderConfig) setupGitEnvironment() (string, []string, string, error) 
 		if err != nil {
 			return "", nil, "", fmt.Errorf("cannot parse build URL: %s", gitSource.URI)
 		}
+		// even though s2i's Parse will strip ssh:// from url's because of golang's inability to parse those
+		// URLs, the scmauth.GithAuths call does not need the sourceURL for correlation with SSHPrivateKey.
 		scmAuths := scmauth.GitAuths(sourceURL)
 
 		secretsEnv, overrideURL, gitConfigFile, err := scmAuths.Setup(c.sourceSecretDir)


### PR DESCRIPTION
/hold 

for now

obviously just a comment

but as we reconcile https://github.com/openshift/oc/pull/875 with https://bugzilla.redhat.com/show_bug.cgi?id=1884270 when @adambkaplan returns from PTO, this comment will help connect the dots if we look at that change in the future and want to understand the connection (or lack there of) between the url and ssh private key

the git url only matter in OCM, when examining builder SA secrets with the build.openshift.io/source-secret-match-uri annotation when deciding whether to mount such secrets (i.e. ssh private keys) in the build pod