### PR TITLE
unprivileged: don't try to set up user namespaces for manage-dockerfile/git-clone

### DIFF
--- a/pkg/build/builder/transient_mounts.go
+++ b/pkg/build/builder/transient_mounts.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -75,6 +76,7 @@ func (t TransientMounts) asSlice() []string {
 	for _, m := range t {
 		mounts = append(mounts, m.String())
 	}
+	sort.Strings(mounts)
 	return mounts
 }
 


### PR DESCRIPTION
Walk back a bit of #220: don't assume that we can set up a user namespace when we're invoked as openshift-manage-dockerfile or openshift-git-clone, even when not explicitly given mappings to use, since those containers haven't traditionally been run with privileged=true.