### PR TITLE
Dockerfiles: run `rpm --setcaps shadow-utils` during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN INSTALL_PKGS=" \
       " && \
     yum install -y --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all
+RUN rpm --setcaps shadow-utils
 COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/bin/
 COPY imagecontent/bin /usr/bin
 COPY imagecontent/etc/containers /etc/containers

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -9,6 +9,7 @@ RUN INSTALL_PKGS=" \
       " && \
     yum install -y --setopt=skip_missing_names_on_install=False ${INSTALL_PKGS} && \
     yum clean all
+RUN rpm --setcaps shadow-utils
 COPY imagecontent/bin /usr/bin
 COPY imagecontent/etc/containers /etc/containers
 COPY imagecontent/usr/share/containers /usr/share/containers

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -11,6 +11,7 @@ RUN INSTALL_PKGS=" \
       " && \
     yum install -y --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all
+RUN rpm --setcaps shadow-utils
 COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/bin/
 COPY imagecontent/bin /usr/bin
 COPY imagecontent/etc/containers /etc/containers

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -10,6 +10,7 @@ RUN INSTALL_PKGS=" \
       " && \
     yum install -y --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all
+RUN rpm --setcaps shadow-utils
 COPY --from=builder /go/src/github.com/openshift/builder/openshift-builder /usr/bin/
 COPY imagecontent/bin /usr/bin
 COPY imagecontent/etc/containers /etc/containers


### PR DESCRIPTION
Our base images don't preserve file capabilities on `/usr/bin/newuidmap` and `/usr/bin/newgidmap`, but they do preserve setuid/setgid bits, which grant more privileges to callers, so go ahead and restore file capabilities during the build.