### PR TITLE
Dockerfile: make certs directories sticky

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p /var/cache/blobs \
     /var/lib/shared/overlay-images \
     /var/lib/shared/overlay-layers \
     /etc/pki/tls/certs /etc/docker/certs.d && \
-    chmod g+w /etc/pki/tls/certs /etc/docker/certs.d && \
+    chmod a+rwxt /etc/pki/tls/certs /etc/docker/certs.d && \
     touch /var/lib/shared/overlay-images/images.lock \
     /var/lib/shared/overlay-layers/layers.lock
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -17,7 +17,7 @@ RUN mkdir -p /var/cache/blobs \
     /var/lib/shared/overlay-images \
     /var/lib/shared/overlay-layers \
     /etc/pki/tls/certs /etc/docker/certs.d && \
-    chmod g+w /etc/pki/tls/certs /etc/docker/certs.d && \
+    chmod a+rwxt /etc/pki/tls/certs /etc/docker/certs.d && \
     touch /var/lib/shared/overlay-images/images.lock \
     /var/lib/shared/overlay-layers/layers.lock
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -20,7 +20,7 @@ RUN mkdir -p /var/cache/blobs \
     /var/lib/shared/overlay-images \
     /var/lib/shared/overlay-layers \
     /etc/pki/tls/certs /etc/docker/certs.d && \
-    chmod g+w /etc/pki/tls/certs /etc/docker/certs.d && \
+    chmod a+rwxt /etc/pki/tls/certs /etc/docker/certs.d && \
     touch /var/lib/shared/overlay-images/images.lock \
     /var/lib/shared/overlay-layers/layers.lock
 

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -19,7 +19,7 @@ RUN mkdir -p /var/cache/blobs \
     /var/lib/shared/overlay-images \
     /var/lib/shared/overlay-layers \
     /etc/pki/tls/certs /etc/docker/certs.d && \
-    chmod g+w /etc/pki/tls/certs /etc/docker/certs.d && \
+    chmod a+rwxt /etc/pki/tls/certs /etc/docker/certs.d && \
     touch /var/lib/shared/overlay-images/images.lock \
     /var/lib/shared/overlay-layers/layers.lock
 


### PR DESCRIPTION
Change the permissions we set on the directories that we use for certificates (/etc/pki/tls/certs and /etc/docker/certs.d) from merely group-writable to being world-writable with the sticky bit, like /tmp tends to be.

If the builder is run as a UID other than 0, it will be able to create new files in these directories, but not modify any of the files provided by the image.