### PR TITLE
unprivileged: ensure that we map 65534,65535

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,9 +70,12 @@ func main() {
 
 	flags := command.Flags()
 	var uidmap, gidmap string
+	var mustMapUIDs, mustMapGIDs string
 	var useNewuidmap, useNewgidmap bool
 	flags.StringVar(&uidmap, "uidmap", "", "re-exec in a user namespace using the specified UID map")
 	flags.StringVar(&gidmap, "gidmap", "", "re-exec in a user namespace using the specified GID map")
+	flags.StringVar(&mustMapUIDs, "must-map-uid", "65534,65535", "ensure that the listed UIDs are mapped for the user namespace")
+	flags.StringVar(&mustMapGIDs, "must-map-gid", "65534,65535", "ensure that the listed GIDs are mapped for the user namespace")
 	flags.BoolVar(&useNewuidmap, "use-newuidmap", os.Geteuid() != 0, "use newuidmap to set up UID mappings")
 	flags.BoolVar(&useNewgidmap, "use-newgidmap", os.Geteuid() != 0, "use newgidmap to set up GID mappings")
 	wrapped := command.Run
@@ -83,7 +86,7 @@ func main() {
 			kcmdutil.CheckErr(err)
 			os.MkdirAll(storeOptions.GraphRoot, 0775)
 			os.MkdirAll(storeOptions.RunRoot, 0775)
-			maybeReexecUsingUserNamespace(uidmap, useNewuidmap, gidmap, useNewgidmap)
+			maybeReexecUsingUserNamespace(uidmap, mustMapUIDs, useNewuidmap, gidmap, mustMapGIDs, useNewgidmap)
 			wrapped(c, args)
 		default:
 			wrapped(c, args)

--- a/cmd/userns_test.go
+++ b/cmd/userns_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustMap(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       []specs.LinuxIDMapping
+		required    []uint32
+		output      []specs.LinuxIDMapping
+	}{
+		{
+			description: "no adjustments necessary",
+			input: []specs.LinuxIDMapping{
+				{
+					HostID:      1000,
+					ContainerID: 0,
+					Size:        1,
+				},
+				{
+					HostID:      100000,
+					ContainerID: 1,
+					Size:        65536,
+				},
+			},
+			required: []uint32{65534, 65535},
+			output: []specs.LinuxIDMapping{
+				{
+					HostID:      1000,
+					ContainerID: 0,
+					Size:        1,
+				},
+				{
+					HostID:      100000,
+					ContainerID: 1,
+					Size:        65536,
+				},
+			},
+		},
+		{
+			description: "shave four",
+			input: []specs.LinuxIDMapping{
+				{
+					HostID:      1000,
+					ContainerID: 0,
+					Size:        1,
+				},
+				{
+					HostID:      100000,
+					ContainerID: 1,
+					Size:        65536,
+				},
+			},
+			required: []uint32{65535, 165534, 165533, 165535},
+			output: []specs.LinuxIDMapping{
+				{
+					HostID:      1000,
+					ContainerID: 0,
+					Size:        1,
+				},
+				{
+					HostID:      100000,
+					ContainerID: 1,
+					Size:        65532,
+				},
+				{
+					HostID:      165532,
+					ContainerID: 65535,
+					Size:        1,
+				},
+				{
+					HostID:      165533,
+					ContainerID: 165533,
+					Size:        1,
+				},
+				{
+					HostID:      165534,
+					ContainerID: 165534,
+					Size:        1,
+				},
+				{
+					HostID:      165535,
+					ContainerID: 165535,
+					Size:        1,
+				},
+			},
+		},
+	}
+	for i := range testCases {
+		t.Run(testCases[i].description, func(t *testing.T) {
+			output, err := mustMap(testCases[i].input, testCases[i].required...)
+			assert.Nil(t, err)
+			assert.Equal(t, testCases[i].output, output)
+		})
+	}
+}


### PR DESCRIPTION
When we set up a user namespace with UID and GID mappings ourselves, default to ensuring that we create mappings in the user namespace for 65534 and 65535, which are used for "nfsnobody" and "nobody" in various base images.

The ranges of IDs which are assigned to namespaces in default setups usually only include 10000 IDs, so these would not be mapped otherwise.