### PR TITLE
Bug 2021551: getAssembleUser(): strip the group part out before checking the UID

### DIFF
--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -600,5 +600,13 @@ func getAssembleUser(docker DockerClient, imageTag string) (string, error) {
 		// If the builder image has the assemble-user label, override with the provided value
 		assembleUser = labelAssembleUser
 	}
-	return assembleUser, nil
+	return extractUser(assembleUser), nil
+}
+
+func extractUser(userSpec string) string {
+	if strings.Contains(userSpec, ":") {
+		parts := strings.SplitN(userSpec, ":", 2)
+		return strings.TrimSpace(parts[0])
+	}
+	return strings.TrimSpace(userSpec)
 }

--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -352,14 +352,30 @@ func TestGetAssembleUser(t *testing.T) {
 			expectedResult: "1002",
 		},
 		{
+			name:           "container user:group set",
+			containerUser:  "1002:1002",
+			expectedResult: "1002",
+		},
+		{
 			name:              "assemble user label set",
 			assembleUserLabel: "1003",
+			expectedResult:    "1003",
+		},
+		{
+			name:              "assemble user:group label set",
+			assembleUserLabel: "1003:1003",
 			expectedResult:    "1003",
 		},
 		{
 			name:              "assemble user override",
 			containerUser:     "1002",
 			assembleUserLabel: "1003",
+			expectedResult:    "1003",
+		},
+		{
+			name:              "assemble user:group override",
+			containerUser:     "1002:1002",
+			assembleUserLabel: "1003:1003",
 			expectedResult:    "1003",
 		},
 	}


### PR DESCRIPTION
If the s2i assemble image's configured user includes a group (i.e., the user spec is in the form "user:group"), strip the group part before checking if the UID is in the range of allowed users.  Borrow `extractUsers()` from `github.com/openshift/source-to-image/pkg/docker` to handle it.