### PR TITLE
Report User/Group ID when they cannot be parsed

### DIFF
--- a/cmd/userns.go
+++ b/cmd/userns.go
@@ -61,7 +61,7 @@ func parseIDMappings(uidmap, gidmap string) ([]specs.LinuxIDMapping, []specs.Lin
 		uid := fmt.Sprintf("%d", os.Geteuid())
 		UIDs, GIDs, err = unshare.GetSubIDMappings(uid, uid)
 		if err != nil {
-			klog.Fatalf("Error reading ID mappings for %s: %v\n", err)
+			klog.Fatalf("Error reading ID mappings for %s: %v\n", uid, err)
 		}
 	}
 	if uidMappings := parseMapping("uidmap", uidmap); len(uidMappings) != 0 {


### PR DESCRIPTION
When complaining about not being able to find any ID mapping ranges for the current user, include the user's name in the error message.