### PR TITLE
Bug 2026297: [release-4.6] Fixing Character Quoting

### DIFF
--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -380,7 +380,7 @@ func TestDockerfilePath(t *testing.T) {
 		"\"OPENSHIFT_BUILD_SOURCE\"=\"http://github.com/openshift/origin.git\"",
 		"\"OPENSHIFT_BUILD_COMMIT\"=\"commitid\"",
 		// expected labels
-		"\"io.openshift.build.commit.author\"=\"test user \\u003ctest@email.com\\u003e\"",
+		"\"io.openshift.build.commit.author\"=\"test user <test@email.com>\"",
 		"\"io.openshift.build.commit.date\"=\"date\"",
 		"\"io.openshift.build.commit.id\"=\"commitid\"",
 		"\"io.openshift.build.commit.ref\"=\"ref\"",

--- a/pkg/build/builder/util/dockerfile/instructions.go
+++ b/pkg/build/builder/util/dockerfile/instructions.go
@@ -1,8 +1,8 @@
 package dockerfile
 
 import (
-	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/openshift/imagebuilder/dockerfile/command"
@@ -38,23 +38,17 @@ func Run(cmd string) (string, error) {
 	return unquotedArgsInstruction(command.Run, cmd)
 }
 
-// keyValueInstruction builds a Dockerfile instruction from the mapping m. Keys
-// and values are serialized as JSON strings to ensure compatibility with the
-// Dockerfile parser. Syntax:
+// keyValueInstruction builds a Dockerfile instruction from the mapping m. Keys and
+// values are quoted and non-printable characters escaped to ensure compatibility
+// with the Dockerfile parser. Syntax:
 //   COMMAND "KEY"="VALUE" "may"="contain spaces"
 func keyValueInstruction(cmd string, m []KeyValue) (string, error) {
 	s := []string{strings.ToUpper(cmd)}
 	for _, kv := range m {
-		// Marshal kv.Key and kv.Value as JSON strings to cover cases
-		// like when the values contain spaces or special characters.
-		k, err := json.Marshal(kv.Key)
-		if err != nil {
-			return "", err
-		}
-		v, err := json.Marshal(kv.Value)
-		if err != nil {
-			return "", err
-		}
+		// Process with 'strconv.Quote' function to allow whitespaces
+		// and escape non-printable and control characters
+		k := strconv.Quote(kv.Key)
+		v := strconv.Quote(kv.Value)
 		s = append(s, fmt.Sprintf("%s=%s", k, v))
 	}
 	return strings.Join(s, " "), nil

--- a/pkg/build/builder/util/dockerfile/instructions_test.go
+++ b/pkg/build/builder/util/dockerfile/instructions_test.go
@@ -65,7 +65,18 @@ func TestKeyValueInstructions(t *testing.T) {
 			in: []KeyValue{
 				{"☃", "'\" \\ / \b \f \n \r \t \x00"},
 			},
-			want: `"☃"="'\" \\ / \u0008 \u000c \n \r \t \u0000"`,
+			want: `"☃"="'\" \\ / \b \f \n \r \t \x00"`,
+		},
+		{
+			// We should verify that HTML symbols < > & are not escaped,
+			// as it is perfectly fine and expected for them to be used
+			// in Dockerfile
+			in: []KeyValue{
+				{"URL", "https://domain.name/key1=val1&key2=val2"},
+				{"NAME", "Person Name <person.name@domain.name>"},
+			},
+			want: `"URL"="https://domain.name/key1=val1&key2=val2"` +
+				` "NAME"="Person Name <person.name@domain.name>"`,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Bringing #215 changes into `release-4.6`. With this PR in place, we have:

```bash
oc new-app https://github.com/openshift/ruby-hello-world --name=ruby-hello

oc start-build ruby-hello --env=ARTIFACT_URL='http://some.url.com/with?query=params&second=param' --env=ARTIFACT_URL_02='http&'
oc rsh ruby-hello-67747b7b6d-qmmks

$ env |grep ART
ARTIFACT_URL_02=http&
ARTIFACT_URL=http://some.url.com/with?query=params&second=param
```
