### PR TITLE
BUILD-433: use the right mappings when we don't need to set any

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -12,7 +12,7 @@ import (
 
 // Return "chroot" if we know we're not actually root, "oci" otherwise.
 func builderDefaultIsolation() (string, error) {
-	if inUserNamespace() {
+	if inOurUserNamespace() {
 		// We probably don't have enough privileges to use a proper
 		// runtime.
 		// Lean on the container that we're in being itself
@@ -50,7 +50,6 @@ func builderDefaultStorage() (string, string, error) {
 	}{
 		{"overlay", `["mountopt=metacopy=on"]`, nil},
 		{"overlay", ``, nil},
-		{"overlay", `["mount_program=/usr/bin/fuse-overlayfs","mountopt=metacopy=on"]`, builderCanUseOverlayFUSE},
 		{"overlay", `["mount_program=/usr/bin/fuse-overlayfs"]`, builderCanUseOverlayFUSE},
 		{"vfs", "", nil},
 	} {

--- a/cmd/userns_test.go
+++ b/cmd/userns_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNodeDefaultMapping(t *testing.T) {
+	cases := []struct {
+		description string
+		mappings    []specs.LinuxIDMapping
+		expected    bool
+	}{
+		{
+			"node defaults",
+			[]specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 0, Size: 0xffffffff},
+			},
+			true,
+		},
+		{
+			"typical isolated namespace",
+			[]specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 100100, Size: 65536},
+			},
+			false,
+		},
+		{
+			"user with subuid",
+			[]specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1001, Size: 1},
+				{ContainerID: 1, HostID: 100100, Size: 65536},
+			},
+			false,
+		},
+		{
+			"multiple ranges",
+			[]specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1001, Size: 1024},
+				{ContainerID: 1024, HostID: 100100, Size: 65536},
+			},
+			false,
+		},
+	}
+	for i := range cases {
+		t.Run(cases[i].description, func(t *testing.T) {
+			assert.Equalf(t, cases[i].expected, isNodeDefaultMapping(cases[i].mappings), "isNodeDefaultMapping(%v)", cases[i].mappings)
+		})
+	}
+}


### PR DESCRIPTION
When we create a new user namespace so that we can get CAP_SYS_ADMIN over a mount namespace, if we're already UID 0, map the current set of ID mappings over themselves instead of trying to repeat the mapping that's been applied to the container we're in.

If we know we've been started in a namespace that doesn't have node-default mappings, log that we know.

Don't default to trying "metacopy=on" with "mount_program=fuse-overlayfs", since it knows nothing about the option and all we do is trigger a repeated warning about it not being recognized.