### PR TITLE
Bug 2071364: Revert "Add --quiet option to buildah if log level is less than 2"

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -326,14 +326,6 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 		PullPushRetryDelay:      DefaultPushOrPullRetryDelay,
 	}
 
-	build_loglevel, err := strconv.Atoi(os.Getenv("BUILD_LOGLEVEL"))
-	if err != nil {
-		return fmt.Errorf("attempting to convert BUILD_LOGLEVEL env var value %q to integer: %s", os.Getenv("BUILD_LOGLEVEL"), err)
-	}
-	if build_loglevel < 2 {
-		options.Quiet = true
-	}
-
 	_, _, err = imagebuildah.BuildDockerfiles(opts.Context, store, options, opts.Dockerfile)
 	return err
 }


### PR DESCRIPTION
This reverts commit 9d0563eb18cfbf39942ff27f8d07643e5093b8a4. This
change breaks all image building tests, example failure: 

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upgrade/1510260330062680064

Error in the logs:

```
error: build error: attempting to convert BUILD_LOGLEVEL env var value "" to integer: strconv.Atoi: parsing "": invalid syntax
```

Per openshift org policy, please merge this revert and build any fix to this off the revert. Please also investigate why the presubmits didn't detect this failure.

