### PR TITLE
Bug 2071364: invalid syntax when parsing empty BUILD_LOGLEVEL

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -325,17 +325,27 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 		MaxPullPushRetries:      DefaultPushOrPullRetryCount,
 		PullPushRetryDelay:      DefaultPushOrPullRetryDelay,
 	}
-
-	build_loglevel, err := strconv.Atoi(os.Getenv("BUILD_LOGLEVEL"))
-	if err != nil {
-		return fmt.Errorf("attempting to convert BUILD_LOGLEVEL env var value %q to integer: %s", os.Getenv("BUILD_LOGLEVEL"), err)
-	}
-	if build_loglevel < 2 {
-		options.Quiet = true
+	if options.Quiet, err = buildahShouldUseQuiet(os.Getenv("BUILD_LOGLEVEL")); err != nil {
+		return err
 	}
 
 	_, _, err = imagebuildah.BuildDockerfiles(opts.Context, store, options, opts.Dockerfile)
 	return err
+}
+
+func buildahShouldUseQuiet(build_loglevel string) (bool, error) {
+	loglevel := 0
+	var err error
+	if len(build_loglevel) != 0 {
+		loglevel, err = strconv.Atoi(build_loglevel)
+		if err != nil {
+			return false, fmt.Errorf("attempting to convert BUILD_LOGLEVEL env var value %q to integer: %s", os.Getenv("BUILD_LOGLEVEL"), err)
+		}
+	}
+	if loglevel < 2 {
+		return true, nil
+	}
+	return false, nil
 }
 
 // appendBuildVolumeMounts appends the Build Volume Mounts to the Transient Mounts Map

--- a/pkg/build/builder/daemonless_test.go
+++ b/pkg/build/builder/daemonless_test.go
@@ -545,3 +545,76 @@ func TestAppendCATrustMount(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildahShouldUseQuiet(t *testing.T) {
+	type args struct {
+		build_loglevel string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "should return true if build_loglevel is empty, and not return an error",
+			args: args{
+				build_loglevel: "",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "should return false if build_loglevel >= 2: case 0",
+			args: args{
+				build_loglevel: "2",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "should return false if build_loglevel >= 2: case 1",
+			args: args{
+				build_loglevel: "3",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "should return false if build_loglevel >= 2: case 2",
+			args: args{
+				build_loglevel: "5",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "should return true if build_loglevel < 2: case 0",
+			args: args{
+				build_loglevel: "0",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "should return true if build_loglevel < 2: case 1",
+			args: args{
+				build_loglevel: "1",
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildahShouldUseQuiet(tt.args.build_loglevel)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildahShouldUseQuiet() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("buildahShouldUseQuiet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Checks for empty BUILD_LOGLEVEL environment variable before attempting
to convert it's content to an integer