### PR TITLE
Set _CONTAINERS_USERNS_CONFIGURED if we create a user namespace

### DIFF
--- a/cmd/userns.go
+++ b/cmd/userns.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const usernsMarkerVariable = "BUILDER_USERNS_CONFIGURED"
+const usernsMarkerVariable = "_CONTAINERS_USERNS_CONFIGURED"
 
 func parseIDMappings(uidmap, gidmap string) ([]specs.LinuxIDMapping, []specs.LinuxIDMapping) {
 	// helper for parsing a string of the form "container:host:size[,container:host:size...]"


### PR DESCRIPTION
Set _CONTAINERS_USERNS_CONFIGURED instead of BUILDER_USERNS_CONFIGURED in the environment if we create our own user namespace, so that various bits of logic that depend on detecting that we're in a rootless mode will do what we need them to do.

In this instance, that's setting extended attributes with names starting with "user.\*" instead of "trusted.\*" when applying layers to disk while pulling images.