### PR TITLE
Bug 2099991: Add support for BUILDAH_QUIET environment variable

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -326,6 +326,11 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 		PullPushRetryDelay:      DefaultPushOrPullRetryDelay,
 	}
 
+	if os.Getenv("BUILDAH_QUIET") == "true" {
+		log.V(4).Infof("Enabling Buildah's --quiet option")
+		options.Quiet = true
+	}
+
 	_, _, err = imagebuildah.BuildDockerfiles(opts.Context, store, options, opts.Dockerfile)
 	return err
 }


### PR DESCRIPTION
Adds the option to set the environment variable BUILDAH_QUIET
on the build config which will enable Buildah's --quiet option
on the build.