### PR TITLE
OCPBUGS-6014: manage-dockerfile: use the original form of HEALTHCHECK

### DIFF
--- a/pkg/build/builder/util/dockerfile/dockerfile.go
+++ b/pkg/build/builder/util/dockerfile/dockerfile.go
@@ -40,7 +40,7 @@ func Write(node *parser.Node) []byte {
 				buf.Write(Write(node.Next.Children[0]))
 			}
 			return buf.Bytes()
-		case command.Env, command.Label:
+		case command.Env, command.Label, command.Healthcheck:
 			buf.Reset()
 			buf.Write([]byte(node.Original + "\n"))
 			return buf.Bytes()

--- a/pkg/build/builder/util/dockerfile/dockerfile_test.go
+++ b/pkg/build/builder/util/dockerfile/dockerfile_test.go
@@ -71,6 +71,7 @@ ENTRYPOINT /bin/sh
 CMD ["-c", "env"]
 USER 1001
 WORKDIR /home
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/usr/bin/true"]
 `,
 			want: `FROM busybox:latest
 MAINTAINER nobody@example.com
@@ -90,6 +91,7 @@ ENTRYPOINT /bin/sh
 CMD ["-c","env"]
 USER 1001
 WORKDIR /home
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/usr/bin/true"]
 `,
 		},
 	}


### PR DESCRIPTION
When reconstructing the Dockerfile, use the original version of a HEALTHCHECK instruction, rather than incorrectly reassembling all of the arguments into a single JSON array.