### PR TITLE
Modified clusterversion patch command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ After your cluster is installed, you will need to do the following:
 1. Patch the cluster version so that you can launch your own builder image:
 
 ```
-$ oc patch clusterversion/version --patch '{"spec":{"overrides":[{"kind":"ConfigMap", "namespace":"openshift-controller-manager-operator","name":"openshift-controller-manager-images","unmanaged":true}]}}' --type=merge
+$ oc patch clusterversion/version --patch '{"spec":{"overrides":[{"group":"v1", "kind":"ConfigMap", "namespace":"openshift-controller-manager-operator", "name":"openshift-controller-manager-images", "unmanaged":true}]}}' --type=merge
 ```
 
 2. Make your code changes and build the binary with `make build`.


### PR DESCRIPTION
While following the steps of [Testing on OpenShift](https://github.com/openshift/builder/blob/master/CONTRIBUTING.md#testing-on-an-openshift-cluster), the patch command failed with the following error:
~~~
$ oc patch clusterversion/version --patch '{"spec":{"overrides":[{"kind":"ConfigMap", "namespace":"openshift-controller-manager-operator","name":"openshift-controller-manager-images","unmanaged":true}]}}' --type=merge
The ClusterVersion "version" is invalid: spec.overrides.group: Required value
~~~

This was tested with `oc` client version v4.10.45 as well as v4.12.0.
Added the `group: v1` to meet the patch required syntax, and the patch was successful.