### PR TITLE
OCPBUGS-3064: normalize locations in pull/push secrets which might look like URLs

### DIFF
--- a/pkg/build/builder/common_test.go
+++ b/pkg/build/builder/common_test.go
@@ -637,6 +637,24 @@ func Test_findReferencedImages(t *testing.T) {
 				Images: []string{"other", "scratch", "test"},
 			},
 		},
+		{
+			original: heredoc.Doc(`
+				ARG headerArg=h
+				FROM other:${headerArg} AS alias
+				ARG middleArg=h
+				COPY --from=testImage /a /b
+				FROM alias as testStage
+				COPY --from=testImage /a /b
+				FROM other:${unsetArg}
+				COPY --from=testStage /a /b
+				FROM other:${headerArg}
+				COPY --from=3 /a /b
+				COPY --from=2 /a /b
+				`),
+			want: want{
+				Images: []string{"3", "other:", "other:h", "testImage"},
+			},
+		},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/pkg/build/builder/daemonless_test.go
+++ b/pkg/build/builder/daemonless_test.go
@@ -63,6 +63,23 @@ func TestMergeNodeCredentials(t *testing.T) {
 			},
 		},
 		{
+			name:      "merge namespace with node credentials (url)",
+			nsCreds:   "testdata/credentials-https-quayio-user0.json",
+			nodeCreds: "testdata/credentials-http-redhatio-nodeuser.json",
+			expected: map[string]credentialprovider.DockerConfigEntry{
+				"quay.io": {
+					Username: "user0",
+					Password: "pass0",
+					Email:    "user0@redhat.com",
+				},
+				"registry.redhat.io": {
+					Username: "nodeuser",
+					Password: "nodepass",
+					Email:    "nodeuser@redhat.com",
+				},
+			},
+		},
+		{
 			name:      "overwriting node credentials",
 			nodeCreds: "testdata/credentials-redhatio-nodeuser.json",
 			nsCreds:   "testdata/credentials-redhatio-nsuser.json",
@@ -75,8 +92,56 @@ func TestMergeNodeCredentials(t *testing.T) {
 			},
 		},
 		{
+			name:      "overwriting node credentials (url 1)",
+			nodeCreds: "testdata/credentials-redhatio-nodeuser.json",
+			nsCreds:   "testdata/credentials-https-redhatio-nsuser.json",
+			expected: map[string]credentialprovider.DockerConfigEntry{
+				"registry.redhat.io": {
+					Username: "nsuser",
+					Password: "nspass",
+					Email:    "nsuser@redhat.com",
+				},
+			},
+		},
+		{
+			name:      "overwriting node credentials (url 2)",
+			nodeCreds: "testdata/credentials-http-redhatio-nodeuser.json",
+			nsCreds:   "testdata/credentials-redhatio-nsuser.json",
+			expected: map[string]credentialprovider.DockerConfigEntry{
+				"registry.redhat.io": {
+					Username: "nsuser",
+					Password: "nspass",
+					Email:    "nsuser@redhat.com",
+				},
+			},
+		},
+		{
+			name:      "overwriting node credentials (url 3)",
+			nodeCreds: "testdata/credentials-http-redhatio-nodeuser.json",
+			nsCreds:   "testdata/credentials-https-redhatio-nsuser.json",
+			expected: map[string]credentialprovider.DockerConfigEntry{
+				"registry.redhat.io": {
+					Username: "nsuser",
+					Password: "nspass",
+					Email:    "nsuser@redhat.com",
+				},
+			},
+		},
+		{
 			name:      "invalid node credentials",
 			nsCreds:   "testdata/credentials-quayio-user0.json",
+			nodeCreds: "testdata/empty.txt",
+			expected: map[string]credentialprovider.DockerConfigEntry{
+				"quay.io": {
+					Username: "user0",
+					Password: "pass0",
+					Email:    "user0@redhat.com",
+				},
+			},
+		},
+		{
+			name:      "invalid node credentials (url)",
+			nsCreds:   "testdata/credentials-https-quayio-user0.json",
 			nodeCreds: "testdata/empty.txt",
 			expected: map[string]credentialprovider.DockerConfigEntry{
 				"quay.io": {
@@ -135,9 +200,59 @@ func TestMergeNodeCredentialsDockerAuth(t *testing.T) {
 			},
 		},
 		{
+			name:    "valid namespace credentials (url)",
+			nsCreds: "testdata/credentials-https-quayio-user0.json",
+			expected: map[string]docker.AuthConfiguration{
+				"quay.io": {
+					Username:      "user0",
+					Password:      "pass0",
+					Email:         "user0@redhat.com",
+					ServerAddress: "quay.io",
+				},
+			},
+		},
+		{
 			name:      "merge namespace with node credentials",
 			nsCreds:   "testdata/credentials-quayio-user0.json",
 			nodeCreds: "testdata/credentials-redhatio-nodeuser.json",
+			expected: map[string]docker.AuthConfiguration{
+				"quay.io": {
+					Username:      "user0",
+					Password:      "pass0",
+					Email:         "user0@redhat.com",
+					ServerAddress: "quay.io",
+				},
+				"registry.redhat.io": {
+					Username:      "nodeuser",
+					Password:      "nodepass",
+					Email:         "nodeuser@redhat.com",
+					ServerAddress: "registry.redhat.io",
+				},
+			},
+		},
+		{
+			name:      "merge namespace with node credentials (url 1)",
+			nsCreds:   "testdata/credentials-https-quayio-user0.json",
+			nodeCreds: "testdata/credentials-redhatio-nodeuser.json",
+			expected: map[string]docker.AuthConfiguration{
+				"quay.io": {
+					Username:      "user0",
+					Password:      "pass0",
+					Email:         "user0@redhat.com",
+					ServerAddress: "quay.io",
+				},
+				"registry.redhat.io": {
+					Username:      "nodeuser",
+					Password:      "nodepass",
+					Email:         "nodeuser@redhat.com",
+					ServerAddress: "registry.redhat.io",
+				},
+			},
+		},
+		{
+			name:      "merge namespace with node credentials (url 2)",
+			nsCreds:   "testdata/credentials-quayio-user0.json",
+			nodeCreds: "testdata/credentials-http-redhatio-nodeuser.json",
 			expected: map[string]docker.AuthConfiguration{
 				"quay.io": {
 					Username:      "user0",
@@ -167,8 +282,60 @@ func TestMergeNodeCredentialsDockerAuth(t *testing.T) {
 			},
 		},
 		{
+			name:      "overwriting node credentials (url 1)",
+			nodeCreds: "testdata/credentials-http-redhatio-nodeuser.json",
+			nsCreds:   "testdata/credentials-redhatio-nsuser.json",
+			expected: map[string]docker.AuthConfiguration{
+				"registry.redhat.io": {
+					Username:      "nsuser",
+					Password:      "nspass",
+					Email:         "nsuser@redhat.com",
+					ServerAddress: "registry.redhat.io",
+				},
+			},
+		},
+		{
+			name:      "overwriting node credentials (url 2)",
+			nodeCreds: "testdata/credentials-redhatio-nodeuser.json",
+			nsCreds:   "testdata/credentials-https-redhatio-nsuser.json",
+			expected: map[string]docker.AuthConfiguration{
+				"registry.redhat.io": {
+					Username:      "nsuser",
+					Password:      "nspass",
+					Email:         "nsuser@redhat.com",
+					ServerAddress: "registry.redhat.io",
+				},
+			},
+		},
+		{
+			name:      "overwriting node credentials (url 3)",
+			nodeCreds: "testdata/credentials-http-redhatio-nodeuser.json",
+			nsCreds:   "testdata/credentials-https-redhatio-nsuser.json",
+			expected: map[string]docker.AuthConfiguration{
+				"registry.redhat.io": {
+					Username:      "nsuser",
+					Password:      "nspass",
+					Email:         "nsuser@redhat.com",
+					ServerAddress: "registry.redhat.io",
+				},
+			},
+		},
+		{
 			name:      "invalid node credentials",
 			nsCreds:   "testdata/credentials-quayio-user0.json",
+			nodeCreds: "testdata/empty.txt",
+			expected: map[string]docker.AuthConfiguration{
+				"quay.io": {
+					Username:      "user0",
+					Password:      "pass0",
+					Email:         "user0@redhat.com",
+					ServerAddress: "quay.io",
+				},
+			},
+		},
+		{
+			name:      "invalid node credentials (url)",
+			nsCreds:   "testdata/credentials-https-quayio-user0.json",
 			nodeCreds: "testdata/empty.txt",
 			expected: map[string]docker.AuthConfiguration{
 				"quay.io": {

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -460,10 +460,6 @@ func (s *S2IBuilder) pullImage(name string, searchPaths []string) error {
 	})
 }
 
-func (s *S2IBuilder) buildImage(optimization buildapiv1.ImageOptimizationPolicy, opts dockerclient.BuildImageOptions) error {
-	return s.dockerClient.BuildImage(opts)
-}
-
 func (s *S2IBuilder) pushImage(name string, authConfig dockerclient.AuthConfiguration) (string, error) {
 	repository, tag := dockerclient.ParseRepositoryTag(name)
 	options := dockerclient.PushImageOptions{

--- a/pkg/build/builder/testdata/credentials-http-redhatio-nodeuser.json
+++ b/pkg/build/builder/testdata/credentials-http-redhatio-nodeuser.json
@@ -1,0 +1,9 @@
+{
+  "auths": {
+    "http://registry.redhat.io/": {
+      "auth": "bm9kZXVzZXI6bm9kZXBhc3M=",
+      "email": "nodeuser@redhat.com"
+    }
+  }
+}
+

--- a/pkg/build/builder/testdata/credentials-https-quayio-user0.json
+++ b/pkg/build/builder/testdata/credentials-https-quayio-user0.json
@@ -1,0 +1,9 @@
+{
+  "auths": {
+    "https://quay.io/v2/": {
+      "auth": "dXNlcjA6cGFzczA=",
+      "email": "user0@redhat.com"
+    }
+  }
+}
+

--- a/pkg/build/builder/testdata/credentials-https-redhatio-nsuser.json
+++ b/pkg/build/builder/testdata/credentials-https-redhatio-nsuser.json
@@ -1,0 +1,9 @@
+{
+  "auths": {
+    "https://registry.redhat.io/v1": {
+      "auth": "bnN1c2VyOm5zcGFzcw==",
+      "email": "nsuser@redhat.com"
+    }
+  }
+}
+

--- a/pkg/build/builder/util/dockerfile/dockerfile.go
+++ b/pkg/build/builder/util/dockerfile/dockerfile.go
@@ -88,6 +88,26 @@ func FindAll(node *parser.Node, cmd string) []int {
 	return indices
 }
 
+// findAllBefore returns the indices of all children of node such that
+// node.Children[i].Value == cmd which occur before any children where
+// node.Children[i].Value == before. Valid values for cmd are defined in the
+// package github.com/docker/docker/builder/dockerfile/command.
+func findAllBefore(node *parser.Node, cmd, before string) []int {
+	if node == nil {
+		return nil
+	}
+	var indices []int
+	for i, child := range node.Children {
+		if child != nil && child.Value == cmd {
+			indices = append(indices, i)
+		}
+		if child != nil && child.Value == before {
+			break
+		}
+	}
+	return indices
+}
+
 // InsertInstructions inserts instructions starting from the pos-th child of
 // node, moving other children as necessary. The instructions should be valid
 // Dockerfile instructions. InsertInstructions mutates node in-place, and the
@@ -109,6 +129,16 @@ func InsertInstructions(node *parser.Node, pos int, instructions string) error {
 	// InsertVector pattern (https://github.com/golang/go/wiki/SliceTricks)
 	node.Children = append(node.Children[:pos], append(newChild.Children, node.Children[pos:]...)...)
 	return nil
+}
+
+// HeaderArgs takes a Dockerfile root node and returns a list of ARGs declared
+// before the first FROM instruction.
+func HeaderArgs(node *parser.Node) []string {
+	var args []string
+	for _, pos := range findAllBefore(node, command.Arg, command.From) {
+		args = append(args, nextValues(node.Children[pos])...)
+	}
+	return args
 }
 
 // baseImages takes a Dockerfile root node and returns a list of all base images

--- a/pkg/build/builder/util_test.go
+++ b/pkg/build/builder/util_test.go
@@ -136,3 +136,64 @@ func TestPathForBuildVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeRegistryLocation(t *testing.T) {
+	tests := []struct{ have, want string }{
+		{"", ""},
+		{"https://docker.io/my-namespace/my-user/my-image", "docker.io/my-namespace/my-user/my-image"},
+		{"https://docker.io/my-namespace", "docker.io/my-namespace"},
+		{"my-registry.local", "my-registry.local"},
+		{"my-registry.local/username", "my-registry.local/username"},
+		{"my-registry.local/v1/username", "my-registry.local/v1/username"},
+		{"my-registry.local/v2/username", "my-registry.local/v2/username"},
+		{"http://my-registry.local/username/", "my-registry.local/username"},
+		{"http://my-registry.local/username", "my-registry.local/username"},
+		{"docker.io/library/alpine", "docker.io/library/alpine"},
+		{"docker.io", "docker.io"},
+		{"quay.io/openshift/art", "quay.io/openshift/art"},
+		{"quay.io/openshift", "quay.io/openshift"},
+		{"quay.io", "quay.io"},
+		{"quay.io/a/b/c", "quay.io/a/b/c"},
+		{"https://registry-1.docker.io/v2/", "docker.io"},
+		{"https://registry-1.docker.io/v2", "docker.io"},
+		{"http://registry-1.docker.io/v1/", "docker.io"},
+		{"http://registry-1.docker.io/v1", "docker.io"},
+		{"https://registry-1.docker.io/", "docker.io"},
+		{"https://registry-1.docker.io", "docker.io"},
+		{"http://registry-1.docker.io/", "docker.io"},
+		{"http://registry-1.docker.io", "docker.io"},
+		{"https://registry-1.docker.io/v2/a", "docker.io/a"},
+		{"https://registry-1.docker.io/v1/b", "docker.io/b"},
+		{"http://registry-1.docker.io/v2/c", "docker.io/c"},
+		{"http://registry-1.docker.io/v1/d", "docker.io/d"},
+		{"https://index.docker.io/v2/", "docker.io"},
+		{"https://index.docker.io/v2", "docker.io"},
+		{"https://index.docker.io/v1/", "docker.io"},
+		{"https://index.docker.io/v1", "docker.io"},
+		{"http://index.docker.io/v2/", "docker.io"},
+		{"http://index.docker.io/v2", "docker.io"},
+		{"http://index.docker.io/v1/", "docker.io"},
+		{"http://index.docker.io/v1", "docker.io"},
+		{"https://index.docker.io/v2/a", "docker.io/a"},
+		{"https://index.docker.io/v1/b", "docker.io/b"},
+		{"http://index.docker.io/v2/c", "docker.io/c"},
+		{"http://index.docker.io/v1/d", "docker.io/d"},
+		{"https://quay.io/v2/", "quay.io"},
+		{"https://quay.io/v2/a", "quay.io/a"},
+		{"https://quay.io/v2", "quay.io"},
+		{"http://quay.io/v2/", "quay.io"},
+		{"http://quay.io/v2", "quay.io"},
+		{"https://quay.io/v1/", "quay.io"},
+		{"https://quay.io/v1", "quay.io"},
+		{"http://quay.io/v1/", "quay.io"},
+		{"http://quay.io/v1/b", "quay.io/b"},
+		{"http://quay.io/v1", "quay.io"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.have, func(t *testing.T) {
+			if got := normalizeRegistryLocation(tt.have); got != tt.want {
+				t.Errorf("normalizeRegistryLocation(%q) = %q, expected %q", tt.have, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Normalize locations in secrets that look like URLs, since we used to accept (or "accept") those.

Updates mergeNodeCredentials(), used by the image pulling logic. Updates mergeNodeCredentialsDockerAuth(), used by the docker and sti strategies. Updates extractSourceFromImage() directly, since it doesn't use either of the other functions.