### PR TITLE
OCPBUGS-1973: pass CPU limits for Docker strategy builds

### DIFF
--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -316,6 +316,9 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 		},
 		CommonBuildOpts: &buildah.CommonBuildOptions{
 			HTTPProxy:          true,
+			CPUPeriod:          uint64(opts.CPUPeriod),
+			CPUShares:          uint64(opts.CPUShares),
+			CPUQuota:           opts.CPUQuota,
 			Memory:             opts.Memory,
 			MemorySwap:         opts.Memswap,
 			CgroupParent:       opts.CgroupParent,

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -336,6 +336,9 @@ func (d *DockerBuilder) dockerBuild(ctx context.Context, dir string, tag string)
 	// adapt, thus we need to set the memory limit at the container level
 	// too, so that information is available to them.
 	if d.cgLimits != nil {
+		opts.CPUPeriod = d.cgLimits.CPUPeriod
+		opts.CPUQuota = d.cgLimits.CPUQuota
+		opts.CPUShares = d.cgLimits.CPUShares
 		opts.Memory = d.cgLimits.MemoryLimitBytes
 		opts.Memswap = d.cgLimits.MemorySwap
 		opts.CgroupParent = d.cgLimits.Parent

--- a/pkg/build/builder/dockerutil_test.go
+++ b/pkg/build/builder/dockerutil_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -153,14 +152,7 @@ func TestReadMaxStringOrInt64(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	for _, tc := range tests {
 		t.Logf("running tc %s", tc.name)
-		fileName := filepath.Join(tmpDir, tc.name)
-		if len(tc.fileContent) > 0 {
-			err = ioutil.WriteFile(fileName, []byte(tc.fileContent), 0644)
-			if err != nil {
-				t.Errorf("error writing data to file %s: %s", fileName, err.Error())
-			}
-		}
-		val, err := readMaxStringOrInt64(fileName)
+		val, err := readMaxStringOrInt64(tc.fileContent)
 		if tc.expectedErr {
 			if err == nil {
 				t.Errorf("test %s expected error and did not get one", tc.name)

--- a/pkg/build/builder/util_linux.go
+++ b/pkg/build/builder/util_linux.go
@@ -15,71 +15,124 @@ import (
 
 // GetCGroupLimits returns a struct populated with cgroup limit values gathered
 // from the local /sys/fs/cgroup filesystem.  Overflow values are set to
-// math.MaxInt64.
+// 92233720368547.
 func GetCGroupLimits() (*s2iapi.CGroupLimits, error) {
+	// we're going to read the contents of various files we care about,
+	// then parse them from the contents, so that we don't need to read
+	// a given file more than once
+	fileContents := make(map[string]string)
 	// see https://git.kernel.org/pub/scm/linux/kernel/git/tj/cgroup.git/tree/Documentation/admin-guide/cgroup-v2.rst
-	// for list of cgroupv2 files to try, but Nalin relayed that examination of the crun and runc code that 'memory.high'
+	// for list of cgroupv2 files to try, but @nalind relayed that examination of the crun and runc code that 'memory.high'
 	// is not used.
-	file := "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	memoryLimitFile := "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	parseMemoryLimitFile := readMaxStringOrInt64
+	cpuQuotaFile := "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+	parseCpuQuotaFile := readMaxStringOrInt64
+	scaleCpuQuota := func(quota int64) int64 { return quota }
+	cpuPeriodFile := "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+	parseCpuPeriodFile := readMaxStringOrInt64
+	scaleCpuPeriod := func(period int64) int64 { return period }
+	cpuSharesFile := "/sys/fs/cgroup/cpu/cpu.shares"
+	parseCpuSharesFile := readMaxStringOrInt64
+	scaleCpuShares := func(shares int64) int64 { return shares }
 	cgroupV2 := cgroups.IsCgroup2UnifiedMode()
+	cgroupVersion := 1
 	if cgroupV2 {
 		// start here in case we are unprivileged
-		file = "/sys/fs/cgroup/memory.max"
-		if _, err := os.Stat(file); err != nil && errors.Is(err, os.ErrNotExist) {
-			cgroupFile, err := cgroups.ParseCgroupFile("/proc/self/cgroup")
-			if err != nil {
-				return nil, err
+		cgroupVersion = 2
+		memoryLimitFile = "/sys/fs/cgroup/memory.max"
+		parseMemoryLimitFile = readMaxStringOrInt64
+		cpuQuotaFile = "/sys/fs/cgroup/cpu.max"
+		parseCpuQuotaFile = readMaxStringsOrInt64s(0)
+		scaleCpuQuota = func(quota int64) int64 { return quota * 10 }
+		cpuPeriodFile = "/sys/fs/cgroup/cpu/cpu.max"
+		parseCpuPeriodFile = readMaxStringsOrInt64s(1)
+		scaleCpuPeriod = func(period int64) int64 { return period * 10 }
+		cpuSharesFile = "/sys/fs/cgroup/cpu/cpu.weight"
+		parseCpuSharesFile = readMaxStringOrInt64
+		scaleCpuShares = func(shares int64) int64 {
+			// scale from [1..10000] (v2 range) to [2..0x40000] (v1 range) to convert weight to shares
+			// borrowed from k8s.io/kubernetes/pkg/kubelet/cm.CpuWeightToCpuShares
+			approximation := (((shares - 1) * 262142) / 9999) + 2
+			switch {
+			case approximation > 262144:
+				return 262144
+			case approximation < 2:
+				return 2
+			default:
+				return approximation
 			}
-			for k, v := range cgroupFile {
-				// the empty key is "special case" in /proc/self/cgroup, and we we use its value to find our specific
-				// pod among all the pods running on the given host, where since we are running as privileged,
-				// /sys/fs/cgroup is bind mounted from the host.
-				if len(strings.TrimSpace(k)) == 0 {
-					file = filepath.Join("/sys/fs/cgroup", v, "memory.max")
-					bytes, e := ioutil.ReadFile(file)
-					if e != nil {
-						// if we have a setting in /proc/self/cgroup but we have problems reading that file,
-						// let's abort as there was an attempt to specify max memory but there is a problem
-						// with the specification
-						return nil, e
-					}
-					contents := ""
-					if bytes != nil {
-						contents = string(bytes)
-					}
-					log.V(5).Infof("using %s for cgroup2 memory.max with value %s", file, contents)
+		}
+		// check if we're privileged, in which case our cgroup will be a subdirectory somewhere below /sys/fs/cgroup
+		cgroupFile, err := cgroups.ParseCgroupFile("/proc/self/cgroup")
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range cgroupFile {
+			// the empty key is a special case in /proc/self/cgroup, and we we use its value to find our specific
+			// pod among all the pods running on the given host, where since we are running as privileged,
+			// /sys/fs/cgroup is bind mounted from the host.
+			if len(strings.TrimSpace(k)) == 0 {
+				// if there's a cgroup there, assume that's where we can find settings that apply to us
+				if _, err := os.Stat(filepath.Join("/sys/fs/cgroup", v, "pids.current")); err == nil {
+					memoryLimitFile = filepath.Join("/sys/fs/cgroup", v, "memory.max")
+					cpuQuotaFile = filepath.Join("/sys/fs/cgroup", v, "cpu.max")
+					cpuPeriodFile = filepath.Join("/sys/fs/cgroup", v, "cpu.max")
+					cpuSharesFile = filepath.Join("/sys/fs/cgroup", v, "cpu.weight")
 				}
 			}
 		}
 	}
-	byteLimit, err := readMaxStringOrInt64(file)
 
-	if err != nil {
-		_, e := os.Stat("/sys/fs/cgroup")
-		notExist := false
-		if e != nil && errors.Is(e, os.ErrNotExist) {
-			notExist = true
+	// read the contents of the three or four files
+	var memoryByteLimit, cpuQuota, cpuPeriod, cpuShares int64
+	var err error
+	for _, filename := range []string{memoryLimitFile, cpuQuotaFile, cpuPeriodFile, cpuSharesFile} {
+		if _, ok := fileContents[filename]; !ok {
+			var b []byte
+			b, err = ioutil.ReadFile(filename)
+			if err != nil {
+				goto returnError
+			}
+			fileContents[filename] = strings.TrimSpace(string(b))
 		}
-		// for systems without cgroups builds should succeed
-		if notExist {
-			return &s2iapi.CGroupLimits{}, nil
-		}
-		// otherwise for cgroupv1 error out
-		if !cgroupV2 {
-			return nil, fmt.Errorf("cannot determine cgroup limits: %w", err)
-		}
-		// if the cgroupv2 error is anything other than file does not exists, error out
-		if !notExist && e != nil {
-			return nil, fmt.Errorf("cannot determine cgroup limits: %w", err)
-		}
-		// otherwise return default for cgroupv2
-		return &s2iapi.CGroupLimits{}, nil
 	}
+	memoryByteLimit, err = parseMemoryLimitFile(fileContents[memoryLimitFile])
+	if err != nil {
+		goto returnError
+	}
+	log.V(5).Infof("using %s for cgroupv%d memory.max with value %s", memoryLimitFile, cgroupVersion, string(fileContents[memoryLimitFile]))
+	cpuQuota, err = parseCpuQuotaFile(fileContents[cpuQuotaFile])
+	if err != nil {
+		goto returnError
+	}
+	cpuQuota = scaleCpuQuota(cpuQuota)
+	log.V(5).Infof("using %s for cgroupv%d cpu.quota_us value %s", cpuQuotaFile, cgroupVersion, string(fileContents[cpuQuotaFile]))
+	cpuPeriod, err = parseCpuPeriodFile(fileContents[cpuPeriodFile])
+	if err != nil {
+		goto returnError
+	}
+	cpuPeriod = scaleCpuPeriod(cpuPeriod)
+	log.V(5).Infof("using %s for cgroupv%d cpu.cfs_period_us value %s", cpuPeriodFile, cgroupVersion, string(fileContents[cpuPeriodFile]))
+	cpuShares, err = parseCpuSharesFile(fileContents[cpuSharesFile])
+	if err != nil {
+		goto returnError
+	}
+	cpuShares = scaleCpuShares(cpuShares)
+	log.V(5).Infof("using %s for cgroupv%d cpu.shares value %s", cpuSharesFile, cgroupVersion, string(fileContents[cpuSharesFile]))
+
 	// math.MaxInt64 seems to give cgroups trouble, this value is
 	// still 92 terabytes, so it ought to be sufficiently large for
 	// our purposes.
-	if byteLimit > 92233720368547 {
-		byteLimit = 92233720368547
+	if memoryByteLimit > 92233720368547 {
+		memoryByteLimit = 92233720368547
+	}
+	// limit the number of microseconds to a million
+	if cpuQuota > 1000000 {
+		cpuQuota = 1000000
+	}
+	if cpuPeriod > 1000000 {
+		cpuPeriod = 1000000
 	}
 
 	return &s2iapi.CGroupLimits{
@@ -87,9 +140,33 @@ func GetCGroupLimits() (*s2iapi.CGroupLimits, error) {
 		// some build containers care what their memory limit is so they can
 		// adapt, thus we need to set the memory limit at the container level
 		// too, so that information is available to them.
-		MemoryLimitBytes: byteLimit,
+		MemoryLimitBytes: memoryByteLimit,
 		// Set memoryswap==memorylimit, this ensures no swapping occurs.
 		// see: https://docs.docker.com/engine/reference/run/#runtime-constraints-on-cpu-and-memory
-		MemorySwap: byteLimit,
+		MemorySwap: memoryByteLimit,
+		CPUShares:  cpuShares,
+		CPUQuota:   cpuQuota,
+		CPUPeriod:  cpuPeriod,
 	}, nil
+
+returnError:
+	_, e := os.Stat("/sys/fs/cgroup")
+	notExist := false
+	if e != nil && errors.Is(e, os.ErrNotExist) {
+		notExist = true
+	}
+	// for systems without cgroups builds should succeed
+	if notExist {
+		return &s2iapi.CGroupLimits{}, nil
+	}
+	// otherwise for cgroupv1 error out
+	if !cgroupV2 {
+		return nil, fmt.Errorf("cannot determine cgroup limits: %w", err)
+	}
+	// if the cgroupv2 error is anything other than file does not exists, error out
+	if !notExist && e != nil {
+		return nil, fmt.Errorf("cannot determine cgroup limits: %w", err)
+	}
+	// otherwise return default for cgroupv2
+	return &s2iapi.CGroupLimits{}, nil
 }


### PR DESCRIPTION
Teach `pkg/build/builder.GetCGroupLimits()` to read cgroups v1 "cpu.shares", "cpu.cfs_quota_us", and "cpu.cfs_period_us" files, and to read more or less equivalent values from v2 "cpu.max" and "cpu.weight" files.

When reading v2 values, scale the "cpu.weight" from the v2 [1..10000] weight range to the v1 [2..0x40000] share range, and scale the "cpu.max" values from the v2 [0..100000] range to the v1 [0..1000000] ranges.

Pick up @coreydaley's changes from #340 to set CPU limits when using the Docker strategy.