### PR TITLE
OCPBUGS-14798: Adds reference to contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # builder
 The image run by build pods to execute image building+pushing
+
+### Looking for contribution guidelines?
+Glad to have you here!  
+Please check [CONTRIBUTING.md](https://github.com/openshift/builder/blob/master/CONTRIBUTING.md) for detailed steps to develop & test the changes.


### PR DESCRIPTION
Adding reference to Contributing.md for someone looking for "how to contribute/where to start".
I've tried to keep it short. Open to suggestions to make it more relatable to the community/end-users :).