### PR TITLE
BUILD-432: mount secrets as "overlay" mounts

### DIFF
--- a/cmd/userns.go
+++ b/cmd/userns.go
@@ -101,8 +101,10 @@ func maybeReexecUsingUserNamespace(uidmap string, useNewuidmap bool, gidmap stri
 
 	// If there's nothing to do, just return.
 	if uidmap == "" && gidmap == "" && os.Geteuid() == 0 {
-		if caps, err := capability.NewPid(0); err == nil && caps.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN) {
-			return
+		if caps, err := capability.NewPid2(0); err == nil {
+			if err := caps.Load(); err == nil && caps.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN) {
+				return
+			}
 		}
 	}
 

--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -375,7 +375,6 @@ func appendBuildVolumeMounts(mountsMap *TransientMounts) error {
 		}
 
 		for _, bvm := range bv.Mounts {
-
 			if err := mountsMap.append(TransientMount{
 				Destination: bvm.DestinationPath,
 				Source:      sourcePath,
@@ -423,9 +422,10 @@ func appendRHRepoMount(pathStart string, mountsMap *TransientMounts) error {
 		Source:      filepath.Join(tmpDir, repoFile),
 		Destination: filepath.Join("/run/secrets", repoFile),
 		Options: TransientMountOptions{
-			NoDev:  true,
-			NoExec: true,
-			NoSuid: true,
+			NoDev:   true,
+			NoExec:  true,
+			NoSuid:  true,
+			Overlay: true,
 		},
 	})
 }
@@ -462,9 +462,10 @@ func coreAppendSecretLinksToDirs(pathStart, pathEnd string, mountsMap *Transient
 		Destination: filepath.Join("/run/secrets", pathEnd),
 		Source:      tmpDir,
 		Options: TransientMountOptions{
-			NoDev:  true,
-			NoExec: true,
-			NoSuid: true,
+			NoDev:   true,
+			NoExec:  true,
+			NoSuid:  true,
+			Overlay: true,
 		},
 	})
 }
@@ -510,6 +511,7 @@ func appendCATrustMount(mountsMap *TransientMounts) error {
 		Source:      "/etc/pki/ca-trust",
 		Options: TransientMountOptions{
 			ReadOnly: &t,
+			Overlay:  true,
 		},
 	})
 }

--- a/pkg/build/builder/daemonless_test.go
+++ b/pkg/build/builder/daemonless_test.go
@@ -705,7 +705,7 @@ func TestAppendCATrustMount(t *testing.T) {
 			if tc.expectMount && len(mounts) == 0 {
 				t.Fatal("expected mount for /etc/pki/ca-trust")
 			}
-			expectedMount := "/etc/pki/ca-trust:/etc/pki/ca-trust:ro"
+			expectedMount := "/etc/pki/ca-trust:/etc/pki/ca-trust:O,ro"
 			if tc.expectMount && mounts[0] != expectedMount {
 				t.Errorf("expected mount %q, got %q", expectedMount, mounts[0])
 			}

--- a/pkg/build/builder/transient_mounts.go
+++ b/pkg/build/builder/transient_mounts.go
@@ -11,6 +11,7 @@ type TransientMountOptions struct {
 	NoDev    bool
 	NoExec   bool
 	NoSuid   bool
+	Overlay  bool
 	ReadOnly *bool
 }
 
@@ -22,7 +23,7 @@ type TransientMount struct {
 }
 
 // returns the string representation of a transient mount
-// format: source:destiation:option1,option2,...
+// format: source:destination:option1,option2,...
 func (tm *TransientMount) String() string {
 	var options []string
 
@@ -34,6 +35,9 @@ func (tm *TransientMount) String() string {
 	}
 	if tm.Options.NoSuid {
 		options = append(options, "nosuid")
+	}
+	if tm.Options.Overlay {
+		options = append(options, "O")
 	}
 	if tm.Options.ReadOnly != nil {
 		if *tm.Options.ReadOnly {

--- a/pkg/build/builder/transient_mounts_test.go
+++ b/pkg/build/builder/transient_mounts_test.go
@@ -185,12 +185,13 @@ func TestTransientMount_String(t *testing.T) {
 				Source:      "/volumes/test1",
 				Destination: "/test1",
 				Options: TransientMountOptions{
-					NoDev:  true,
-					NoExec: true,
-					NoSuid: true,
+					NoDev:   true,
+					NoExec:  true,
+					NoSuid:  true,
+					Overlay: true,
 				},
 			},
-			want: "/volumes/test1:/test1:nodev,noexec,nosuid",
+			want: "/volumes/test1:/test1:nodev,noexec,nosuid,O",
 		},
 		{
 			name: "mount with all false",


### PR DESCRIPTION
Mount secrets as "overlay" mounts, so that we can more easily mark them as noexec/nosuid/nodev in unprivileged builds, where attempting to change the mount flags on a bind mount in an unprivileged namespace would trigger errors.

Log which capabilities we have at startup at level 2 or higher, and use the newer API to check if we have CAP_SYS_ADMIN.