### PR TITLE
OCPBUGS-35283: Bumps openshift/api & related dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/opencontainers/runc v1.1.9
 	github.com/opencontainers/runtime-spec v1.1.0
-	github.com/openshift/api v0.0.0-20231018090736-41ecc021ff27
+	github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
 	github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6
 	github.com/openshift/imagebuilder v1.2.5
 	github.com/openshift/library-go v0.0.0-20231017173800-126f85ed0cc7

--- a/go.sum
+++ b/go.sum
@@ -398,8 +398,8 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20230317050512-e931285f4b69 h1:
 github.com/opencontainers/runtime-tools v0.9.1-0.20230317050512-e931285f4b69/go.mod h1:bNpfuSHA3DZRtD0TPWO8LzgtLpFPTVA/3jDkzD/OPyk=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift/api v0.0.0-20231018090736-41ecc021ff27 h1:F+OfUDnk9/F5PL5cgDTzm3D+S/n9oPbzEm9dNpwel0w=
-github.com/openshift/api v0.0.0-20231018090736-41ecc021ff27/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
+github.com/openshift/api v0.0.0-20240522145529-93d6bda14341 h1:JQpzgk+p24rkgNbNsrNR0yLm63WTKapuT60INU5BqT8=
+github.com/openshift/api v0.0.0-20240522145529-93d6bda14341/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6 h1:3wgEtuYbZ76oOXjhSJ2p1m0lftgghK0XlR9guG2aKhA=
 github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6/go.mod h1:Fkn7VRruQ4KwNGeaUmi9QgqLk/d7U6cj+UiP8b+0hiQ=
 github.com/openshift/imagebuilder v1.2.5 h1:dby0N3FTouXSBgWNf+gfTkj36fAb8g4iL/SRw1eNAoo=

--- a/vendor/github.com/openshift/api/build/v1/consts.go
+++ b/vendor/github.com/openshift/api/build/v1/consts.go
@@ -164,9 +164,11 @@ const (
 	StatusReasonBuildPodEvicted StatusReason = "BuildPodEvicted"
 )
 
-// env vars
-// WhitelistEnvVarNames is a list of special env vars allows s2i containers
-var WhitelistEnvVarNames = []string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY", "HTTP_PROXY", "HTTPS_PROXY", "LANG", "NO_PROXY"}
+// WhitelistEnvVarNames is a list of environment variable names that are allowed to be specified
+// in a buildconfig and merged into the created build pods, the code for this is located in
+// openshift/openshift-controller-manager
+var WhitelistEnvVarNames = []string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY", "GIT_LFS_SKIP_SMUDGE", "LANG",
+	"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"}
 
 // env vars
 const (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -661,7 +661,7 @@ github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift/api v0.0.0-20231018090736-41ecc021ff27
+# github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
 ## explicit; go 1.20
 github.com/openshift/api/build/v1
 # github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6


### PR DESCRIPTION
The current vendored version of openshift/api doesn't include the changes merged with https://github.com/openshift/api/pull/1674. This commit bumps the openshift/api to the latest release-4.15 branch.