### PR TITLE
builder/daemonless: pass through `/dev/kvm` if present

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ $ oc patch configmap openshift-controller-manager-images -n openshift-controller
 6. Watch the openshift controller manager pods rollout (this can take a few minutes):
 
 ```
-$ oc get ds controller-manager -n openshift-controller-manager -w
+$ oc get deployment controller-manager -n openshift-controller-manager -w
 ```
 
 7. Trigger an OpenShift build via `oc start-build`. You can use one of the templates suggested in `oc new-app` to populate your project with a build.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,11 +1,11 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:40
 LABEL io.k8s.display-name="OpenShift Origin Builder" \
       io.k8s.description="This is a component of OpenShift Origin and is responsible for executing image builds." \
       io.openshift.tags="openshift,builder"
 
 RUN INSTALL_PKGS=" \
       bind-utils bsdtar findutils fuse-overlayfs git hostname lsof \
-      procps-ng runc socat tar tree util-linux wget which glibc\
+      procps-ng runc socat tar tree util-linux wget which glibc netavark \
       " && \
     yum install -y --setopt=skip_missing_names_on_install=False ${INSTALL_PKGS} && \
     yum clean all

--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -298,6 +298,13 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 	// in runtime-tools's generator logic.
 	seccompProfilePath := "/usr/share/containers/seccomp.json"
 
+	// If we have /dev/kvm, pass it down to the build process since it likely means
+	// that it was allocated to us with that expectation.
+	devices := []string{}
+	if _, err := os.Stat("/dev/kvm"); err == nil {
+		devices = append(devices, "/dev/kvm")
+	}
+
 	options := imagebuildah.BuildOptions{
 		ContextDirectory: contextDir,
 		PullPolicy:       pullPolicy,
@@ -334,6 +341,7 @@ func buildDaemonlessImage(sc types.SystemContext, store storage.Store, isolation
 		MaxPullPushRetries:      DefaultPushOrPullRetryCount,
 		PullPushRetryDelay:      DefaultPushOrPullRetryDelay,
 		SkipUnusedStages:        types.OptionalBoolFalse,
+		Devices:                 devices,
 	}
 
 	if os.Getenv("BUILDAH_QUIET") == "true" {


### PR DESCRIPTION
Currently, if `devices.kubevirt.io/kvm` resources are requested in the
build object, the resource request makes it to the build pod, but it
doesn't really have any visible effect because the nested build process
itself doesn't have access to it.

The only reason we'd have `/dev/kvm` in our pod is if the user wants to
use it in their build. So just pass it through if we find it.

The use case for this is being able to build artifacts which would
normally require privileges.

One example includes base bootable container (bootc) images.
Building these currently requires privileges because it itself uses
containerization features.

In the future, this should work with user namespacing, currently in Tech
Preview. However, because we need not just uid 0 but `CAP_SYS_ADMIN`,
and capabilities would still be restricted by default, we would still
require access to non-default SCCs. (And of course, the builder would
also have to be adapted to pass through the capabilities.)

Another example is building disk images and shipping them in container
images. This is done for example by Kubevirt and podman-machine. Two
common ways to build disk images currently are via loopback devices or
virtualization. The former can't be used because loopback devices are
not namespaced and require privileges. This patch enables the latter.

Using virtualization enables us to build these artifacts all while using
the _default_ OpenShift restricted SCC.

