### PR TITLE
OCPBUGS-43296: Bump buildah to 1.26.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
-	github.com/containers/buildah v1.26.6
+	github.com/containers/buildah v1.26.9
 	github.com/containers/common v0.49.1
 	github.com/containers/image/v5 v5.22.0
 	github.com/containers/storage v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl3
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNGz0C1d3wVYlHE=
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
-github.com/containers/buildah v1.26.6 h1:e2wjBGoeyXezmMLJHyTJ58VhTB0DJPcSP59S3e2fBYY=
-github.com/containers/buildah v1.26.6/go.mod h1:GXyNVMyV7wW4Qnw2AUjLnyTRlgGMNcgW8aF/U3qLYPA=
+github.com/containers/buildah v1.26.9 h1:mCNO8y0uc7MP9W9na+yQGM80ylKucLJIgQG+3bgdpN4=
+github.com/containers/buildah v1.26.9/go.mod h1:GXyNVMyV7wW4Qnw2AUjLnyTRlgGMNcgW8aF/U3qLYPA=
 github.com/containers/common v0.49.1 h1:6y4/s2WwYxrv+Cox7fotOo316wuZI+iKKPUQweCYv50=
 github.com/containers/common v0.49.1/go.mod h1:ueM5hT0itKqCQvVJDs+EtjornAQtrHYxQJzP2gxeGIg=
 github.com/containers/image/v5 v5.22.0 h1:KemxPmD4D2YYOFZN2SgoTk7nBFcnwPiPW0MqjYtknSE=

--- a/vendor/github.com/containers/buildah/.cirrus.yml
+++ b/vendor/github.com/containers/buildah/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "release-1.26"
     GOPATH: "/var/tmp/go"
     GOSRC: "${GOPATH}/src/github.com/containers/buildah"
     # Overrides default location (/tmp/cirrus) for repo clone
@@ -137,9 +137,10 @@ cross_build_task:
     only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     osx_instance:
-        image: 'big-sur-base'
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
     script:
+        - brew upgrade
         - brew update
         - brew install go
         - brew install go-md2man
@@ -185,7 +186,7 @@ conformance_task:
     gce_instance:
         image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
-    timeout_in: 25m
+    timeout_in: 45m
 
     matrix:
         - env:

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 # Changelog
 
+## v1.26.9 (2025-01-24)
+
+    Add build-tag comments
+    Fix cache locks with multiple mounts
+    Disable windows cross compile targets
+    Fix TOCTOU error when bind and cache mounts use "src" values
+    define.TempDirForURL(): always use an intermediate subdirectory
+    internal/volume.GetBindMount(): discard writes in bind mounts
+    pkg/overlay: add a MountLabel flag to Options
+    pkg/overlay: add a ForceMount flag to Options
+    Add internal/volumes.bindFromChroot()
+    Add an internal/open package
+    Allow cache mounts to be stages or additional build contexts
+
+## v1.26.8 (2024-10-21)
+
+    Properly validate cache IDs and sources
+
+## v1.26.7 (2024-04-01)
+
+    [release-1.26] conformance tests: don't break on trailing zeroes
+    [release-1.26] CVE-2024-1753 container escape fix
+    Mask /sys/devices/virtual/powercap by default
+    Use docker.io/library/centos instead of the one at registry.centos.org
+    Run the cross-compile test on M1 MacOS, not Intel
+
 ## v1.26.6 (2022-12-08)
 
     copier.Put(): clear up os/syscall mode bit confusion

--- a/vendor/github.com/containers/buildah/Makefile
+++ b/vendor/github.com/containers/buildah/Makefile
@@ -77,7 +77,8 @@ buildah: bin/buildah
 ALL_CROSS_TARGETS := $(addprefix bin/buildah.,$(subst /,.,$(shell $(GO) tool dist list | grep -v loong64)))
 LINUX_CROSS_TARGETS := $(filter bin/buildah.linux.%,$(ALL_CROSS_TARGETS))
 DARWIN_CROSS_TARGETS := $(filter bin/buildah.darwin.%,$(ALL_CROSS_TARGETS))
-WINDOWS_CROSS_TARGETS := $(addsuffix .exe,$(filter bin/buildah.windows.%,$(ALL_CROSS_TARGETS)))
+#WINDOWS_CROSS_TARGETS := $(addsuffix .exe,$(filter bin/buildah.windows.%,$(ALL_CROSS_TARGETS)))
+WINDOWS_CROSS_TARGETS :=
 .PHONY: cross
 cross: $(LINUX_CROSS_TARGETS) $(DARWIN_CROSS_TARGETS) $(WINDOWS_CROSS_TARGETS)
 

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,26 @@
+- Changelog for v1.26.9 (2025-01-24)
+  * Add build-tag comments
+  * Fix cache locks with multiple mounts
+  * Disable windows cross compile targets
+  * Fix TOCTOU error when bind and cache mounts use "src" values
+  * define.TempDirForURL(): always use an intermediate subdirectory
+  * internal/volume.GetBindMount(): discard writes in bind mounts
+  * pkg/overlay: add a MountLabel flag to Options
+  * pkg/overlay: add a ForceMount flag to Options
+  * Add internal/volumes.bindFromChroot()
+  * Add an internal/open package
+  * Allow cache mounts to be stages or additional build contexts
+
+- Changelog for v1.26.8 (2024-10-21)
+  * Properly validate cache IDs and sources
+
+- Changelog for v1.26.7 (2024-04-01)
+  * [release-1.26] conformance tests: don't break on trailing zeroes
+  * [release-1.26] CVE-2024-1753 container escape fix
+  * Mask /sys/devices/virtual/powercap by default
+  * Use docker.io/library/centos instead of the one at registry.centos.org
+  * Run the cross-compile test on M1 MacOS, not Intel
+
 - Changelog for v1.26.6 (2022-12-08)
   * copier.Put(): clear up os/syscall mode bit confusion
 

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -29,7 +29,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.26.6"
+	Version = "1.26.9"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"
@@ -103,13 +103,13 @@ type BuildOutputOption struct {
 	IsStdout bool
 }
 
-// TempDirForURL checks if the passed-in string looks like a URL or -.  If it is,
-// TempDirForURL creates a temporary directory, arranges for its contents to be
-// the contents of that URL, and returns the temporary directory's path, along
-// with the name of a subdirectory which should be used as the build context
-// (which may be empty or ".").  Removal of the temporary directory is the
-// responsibility of the caller.  If the string doesn't look like a URL,
-// TempDirForURL returns empty strings and a nil error code.
+// TempDirForURL checks if the passed-in string looks like a URL or "-".  If it
+// is, TempDirForURL creates a temporary directory, arranges for its contents
+// to be the contents of that URL, and returns the temporary directory's path,
+// along with the relative name of a subdirectory which should be used as the
+// build context (which may be empty or ".").  Removal of the temporary
+// directory is the responsibility of the caller.  If the string doesn't look
+// like a URL or "-", TempDirForURL returns empty strings and a nil error code.
 func TempDirForURL(dir, prefix, url string) (name string, subdir string, err error) {
 	if !strings.HasPrefix(url, "http://") &&
 		!strings.HasPrefix(url, "https://") &&
@@ -122,19 +122,24 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	if err != nil {
 		return "", "", errors.Wrapf(err, "error creating temporary directory for %q", url)
 	}
+	downloadDir := filepath.Join(name, "download")
+	if err = os.MkdirAll(downloadDir, 0o700); err != nil {
+		return "", "", fmt.Errorf("creating directory %q for %q: %w", downloadDir, url, err)
+	}
 	urlParsed, err := urlpkg.Parse(url)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "error parsing url %q", url)
 	}
 	if strings.HasPrefix(url, "git://") || strings.HasSuffix(urlParsed.Path, ".git") {
-		combinedOutput, err := cloneToDirectory(url, name)
+		combinedOutput, err := cloneToDirectory(url, downloadDir)
 		if err != nil {
 			if err2 := os.RemoveAll(name); err2 != nil {
 				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
 			}
 			return "", "", errors.Wrapf(err, "cloning %q to %q:\n%s", url, name, string(combinedOutput))
 		}
-		return name, "", nil
+		logrus.Debugf("Build context is at %q", downloadDir)
+		return name, filepath.Base(downloadDir), nil
 	}
 	if strings.HasPrefix(url, "github.com/") {
 		ghurl := url
@@ -143,28 +148,29 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 		subdir = path.Base(ghurl) + "-master"
 	}
 	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-		err = downloadToDirectory(url, name)
+		err = downloadToDirectory(url, downloadDir)
 		if err != nil {
 			if err2 := os.RemoveAll(name); err2 != nil {
 				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
 			}
-			return "", subdir, err
+			return "", "", err
 		}
-		return name, subdir, nil
+		logrus.Debugf("Build context is at %q", filepath.Join(downloadDir, subdir))
+		return name, filepath.Join(filepath.Base(downloadDir), subdir), nil
 	}
 	if url == "-" {
-		err = stdinToDirectory(name)
+		err = stdinToDirectory(downloadDir)
 		if err != nil {
 			if err2 := os.RemoveAll(name); err2 != nil {
 				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
 			}
-			return "", subdir, err
+			return "", "", err
 		}
-		logrus.Debugf("Build context is at %q", name)
-		return name, subdir, nil
+		logrus.Debugf("Build context is at %q", filepath.Join(downloadDir, subdir))
+		return name, filepath.Join(filepath.Base(downloadDir), subdir), nil
 	}
 	logrus.Debugf("don't know how to retrieve %q", url)
-	if err2 := os.Remove(name); err2 != nil {
+	if err2 := os.RemoveAll(name); err2 != nil {
 		logrus.Debugf("error removing temporary directory %q: %v", name, err2)
 	}
 	return "", "", errors.Errorf("unreachable code reached")

--- a/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/stage_executor.go
@@ -514,7 +514,11 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 							// to `mountPoint` replaced from additional
 							// build-context. Reason: Parser will use this
 							//  `from` to refer from stageMountPoints map later.
-							stageMountPoints[from] = internal.StageMountDetails{IsStage: false, MountPoint: mountPoint}
+							stageMountPoints[from] = internal.StageMountDetails{
+								IsAdditionalBuildContext: true,
+								IsImage:                  true,
+								MountPoint:               mountPoint,
+							}
 							break
 						} else {
 							// Most likely this points to path on filesystem
@@ -546,7 +550,10 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 									mountPoint = additionalBuildContext.DownloadedCache
 								}
 							}
-							stageMountPoints[from] = internal.StageMountDetails{IsStage: true, MountPoint: mountPoint}
+							stageMountPoints[from] = internal.StageMountDetails{
+								IsAdditionalBuildContext: true,
+								MountPoint:               mountPoint,
+							}
 							break
 						}
 					}
@@ -557,14 +564,20 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 						return nil, err
 					}
 					if otherStage, ok := s.executor.stages[from]; ok && otherStage.index < s.index {
-						stageMountPoints[from] = internal.StageMountDetails{IsStage: true, MountPoint: otherStage.mountPoint}
+						stageMountPoints[from] = internal.StageMountDetails{
+							IsStage:    true,
+							MountPoint: otherStage.mountPoint,
+						}
 						break
 					} else {
 						mountPoint, err := s.getImageRootfs(s.ctx, from)
 						if err != nil {
 							return nil, errors.Errorf("%s from=%s: no stage or image found with that name", flag, from)
 						}
-						stageMountPoints[from] = internal.StageMountDetails{IsStage: false, MountPoint: mountPoint}
+						stageMountPoints[from] = internal.StageMountDetails{
+							IsImage:    true,
+							MountPoint: mountPoint,
+						}
 						break
 					}
 				default:

--- a/vendor/github.com/containers/buildah/install.md
+++ b/vendor/github.com/containers/buildah/install.md
@@ -323,7 +323,7 @@ cat /etc/containers/registries.conf
 # and 'registries.block'.
 
 [registries.search]
-registries = ['docker.io', 'registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com', 'registry.centos.org']
+registries = ['docker.io', 'registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com']
 
 # If you need to access insecure registries, add the registry's fully-qualified name.
 # An insecure registry is one that does not have a valid SSL certificate or only does HTTP.

--- a/vendor/github.com/containers/buildah/internal/open/open.go
+++ b/vendor/github.com/containers/buildah/internal/open/open.go
@@ -1,0 +1,39 @@
+package open
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// InChroot opens the file at `path` after chrooting to `root` and then
+// changing its working directory to `wd`.  Both `wd` and `path` are evaluated
+// in the chroot.
+// Returns a file handle, an Errno value if there was an error and the
+// underlying error was a standard library error code, and a non-empty error if
+// one was detected.
+func InChroot(root, wd, path string, mode int, perm uint32) (fd int, errno syscall.Errno, err error) {
+	requests := requests{
+		Root: root,
+		Wd:   wd,
+		Open: []request{
+			{
+				Path:  path,
+				Mode:  mode,
+				Perms: perm,
+			},
+		},
+	}
+	results := inChroot(requests)
+	if len(results.Open) != 1 {
+		return -1, 0, fmt.Errorf("got %d results back instead of 1", len(results.Open))
+	}
+	if results.Open[0].Err != "" {
+		if results.Open[0].Errno != 0 {
+			err = fmt.Errorf("%s: %w", results.Open[0].Err, results.Open[0].Errno)
+		} else {
+			err = errors.New(results.Open[0].Err)
+		}
+	}
+	return int(results.Open[0].Fd), results.Open[0].Errno, err
+}

--- a/vendor/github.com/containers/buildah/internal/open/open_linux.go
+++ b/vendor/github.com/containers/buildah/internal/open/open_linux.go
@@ -1,0 +1,88 @@
+package open
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/storage/pkg/reexec"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	bindFdToPathCommand = "buildah-bind-fd-to-path"
+)
+
+func init() {
+	reexec.Register(bindFdToPathCommand, bindFdToPathMain)
+}
+
+// BindFdToPath creates a bind mount from the open file (which is actually a
+// directory) to the specified location.  If it succeeds, the caller will need
+// to unmount the targetPath when it's finished using it.  Regardless, it
+// closes the passed-in descriptor.
+func BindFdToPath(fd uintptr, targetPath string) error {
+	f := os.NewFile(fd, "passed-in directory descriptor")
+	defer func() {
+		if err := f.Close(); err != nil {
+			logrus.Debugf("closing descriptor %d after attempting to bind to %q: %v", fd, targetPath, err)
+		}
+	}()
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	cmd := reexec.Command(bindFdToPathCommand)
+	cmd.Stdin = pipeReader
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	cmd.ExtraFiles = append(cmd.ExtraFiles, f)
+
+	err = cmd.Start()
+	pipeReader.Close()
+	if err != nil {
+		pipeWriter.Close()
+		return fmt.Errorf("starting child: %w", err)
+	}
+
+	encoder := json.NewEncoder(pipeWriter)
+	if err := encoder.Encode(&targetPath); err != nil {
+		return fmt.Errorf("sending target path to child: %w", err)
+	}
+	pipeWriter.Close()
+	err = cmd.Wait()
+	trimmedOutput := strings.TrimSpace(stdout.String()) + strings.TrimSpace(stderr.String())
+	if err != nil {
+		if len(trimmedOutput) > 0 {
+			err = fmt.Errorf("%s: %w", trimmedOutput, err)
+		}
+	} else {
+		if len(trimmedOutput) > 0 {
+			err = errors.New(trimmedOutput)
+		}
+	}
+	return err
+}
+
+func bindFdToPathMain() {
+	var targetPath string
+	decoder := json.NewDecoder(os.Stdin)
+	if err := decoder.Decode(&targetPath); err != nil {
+		fmt.Fprintf(os.Stderr, "error decoding target path")
+		os.Exit(1)
+	}
+	if err := unix.Fchdir(3); err != nil {
+		fmt.Fprintf(os.Stderr, "fchdir(): %v", err)
+		os.Exit(1)
+	}
+	if err := unix.Mount(".", targetPath, "bind", unix.MS_BIND, ""); err != nil {
+		fmt.Fprintf(os.Stderr, "bind-mounting passed-in directory to %q: %v", targetPath, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/vendor/github.com/containers/buildah/internal/open/open_types.go
+++ b/vendor/github.com/containers/buildah/internal/open/open_types.go
@@ -1,0 +1,28 @@
+package open
+
+import (
+	"syscall"
+)
+
+type request struct {
+	Path  string
+	Mode  int
+	Perms uint32
+}
+
+type requests struct {
+	Root string
+	Wd   string
+	Open []request
+}
+
+type result struct {
+	Fd    uintptr       // as returned by open()
+	Err   string        // if err was not `nil`, err.Error()
+	Errno syscall.Errno // if err was not `nil` and included a syscall.Errno, its value
+}
+
+type results struct {
+	Err  string
+	Open []result
+}

--- a/vendor/github.com/containers/buildah/internal/open/open_unix.go
+++ b/vendor/github.com/containers/buildah/internal/open/open_unix.go
@@ -1,0 +1,169 @@
+//go:build linux || freebsd || darwin
+// +build linux freebsd darwin
+
+package open
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/containers/storage/pkg/reexec"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	inChrootCommand = "buildah-open-in-chroot"
+)
+
+func init() {
+	reexec.Register(inChrootCommand, inChrootMain)
+}
+
+func inChroot(requests requests) results {
+	sock, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return results{Err: fmt.Errorf("creating socket pair: %w", err).Error()}
+	}
+	parentSock := sock[0]
+	childSock := sock[1]
+	parentEnd := os.NewFile(uintptr(parentSock), "parent end of socket pair")
+	childEnd := os.NewFile(uintptr(childSock), "child end of socket pair")
+	cmd := reexec.Command(inChrootCommand)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, childEnd)
+	err = cmd.Start()
+	childEnd.Close()
+	defer parentEnd.Close()
+	if err != nil {
+		return results{Err: err.Error()}
+	}
+	encoder := json.NewEncoder(parentEnd)
+	if err := encoder.Encode(&requests); err != nil {
+		return results{Err: fmt.Errorf("sending request down socket: %w", err).Error()}
+	}
+	if err := unix.Shutdown(parentSock, unix.SHUT_WR); err != nil {
+		return results{Err: fmt.Errorf("finishing sending request down socket: %w", err).Error()}
+	}
+	b := make([]byte, 65536)
+	oob := make([]byte, 65536)
+	n, oobn, _, _, err := unix.Recvmsg(parentSock, b, oob, 0)
+	if err != nil {
+		return results{Err: fmt.Errorf("receiving message: %w", err).Error()}
+	}
+	if err := unix.Shutdown(parentSock, unix.SHUT_RD); err != nil {
+		return results{Err: fmt.Errorf("finishing socket: %w", err).Error()}
+	}
+	if n > len(b) {
+		return results{Err: fmt.Errorf("too much regular data: %d > %d", n, len(b)).Error()}
+	}
+	if oobn > len(oob) {
+		return results{Err: fmt.Errorf("too much OOB data: %d > %d", oobn, len(oob)).Error()}
+	}
+	scms, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		return results{Err: fmt.Errorf("parsing control message: %w", err).Error()}
+	}
+	var receivedFds []int
+	for i := range scms {
+		fds, err := unix.ParseUnixRights(&scms[i])
+		if err != nil {
+			return results{Err: fmt.Errorf("parsing rights message %d: %w", i, err).Error()}
+		}
+		receivedFds = append(receivedFds, fds...)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(b[:n]))
+	var result results
+	if err := decoder.Decode(&result); err != nil {
+		return results{Err: fmt.Errorf("decoding results: %w", err).Error()}
+	}
+	j := 0
+	for i := range result.Open {
+		if result.Open[i].Err == "" {
+			if j >= len(receivedFds) {
+				for _, fd := range receivedFds {
+					unix.Close(fd)
+				}
+				return results{Err: fmt.Errorf("didn't receive enough FDs").Error()}
+			}
+			result.Open[i].Fd = uintptr(receivedFds[j])
+			j++
+		}
+	}
+	return result
+}
+
+func inChrootMain() {
+	var theseRequests requests
+	var theseResults results
+	sockFd := 3
+	sock := os.NewFile(uintptr(sockFd), "socket connection to parent process")
+	defer sock.Close()
+	encoder := json.NewEncoder(sock)
+	decoder := json.NewDecoder(sock)
+	if err := decoder.Decode(&theseRequests); err != nil {
+		if err := encoder.Encode(results{Err: fmt.Errorf("decoding request: %w", err).Error()}); err != nil {
+			os.Exit(1)
+		}
+	}
+	if theseRequests.Root != "" {
+		if err := os.Chdir(theseRequests.Root); err != nil {
+			if err := encoder.Encode(results{Err: fmt.Errorf("changing to %q: %w", theseRequests.Root, err).Error()}); err != nil {
+				os.Exit(1)
+			}
+			os.Exit(1)
+		}
+		if err := unix.Chroot(theseRequests.Root); err != nil {
+			if err := encoder.Encode(results{Err: fmt.Errorf("chrooting to %q: %w", theseRequests.Root, err).Error()}); err != nil {
+				os.Exit(1)
+			}
+			os.Exit(1)
+		}
+		if err := os.Chdir("/"); err != nil {
+			if err := encoder.Encode(results{Err: fmt.Errorf("changing to new root: %w", err).Error()}); err != nil {
+				os.Exit(1)
+			}
+			os.Exit(1)
+		}
+	}
+	if theseRequests.Wd != "" {
+		if err := os.Chdir(theseRequests.Wd); err != nil {
+			if err := encoder.Encode(results{Err: fmt.Errorf("changing to %q in chroot: %w", theseRequests.Wd, err).Error()}); err != nil {
+				os.Exit(1)
+			}
+			os.Exit(1)
+		}
+	}
+	var fds []int
+	for _, request := range theseRequests.Open {
+		fd, err := unix.Open(request.Path, request.Mode, request.Perms)
+		thisResult := result{Fd: uintptr(fd)}
+		if err == nil {
+			fds = append(fds, fd)
+		} else {
+			var errno syscall.Errno
+			thisResult.Err = err.Error()
+			if errors.As(err, &errno) {
+				thisResult.Errno = errno
+			}
+		}
+		theseResults.Open = append(theseResults.Open, thisResult)
+	}
+	rights := unix.UnixRights(fds...)
+	inband, err := json.Marshal(&theseResults)
+	if err != nil {
+		if err := encoder.Encode(results{Err: fmt.Errorf("sending response: %w", err).Error()}); err != nil {
+			os.Exit(1)
+		}
+		os.Exit(1)
+	}
+	if err := unix.Sendmsg(sockFd, inband, rights, nil, 0); err != nil {
+		if err := encoder.Encode(results{Err: fmt.Errorf("sending response: %w", err).Error()}); err != nil {
+			os.Exit(1)
+		}
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/vendor/github.com/containers/buildah/internal/open/open_unsupported.go
+++ b/vendor/github.com/containers/buildah/internal/open/open_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux && !freebsd && !darwin
+// +build !linux,!freebsd,!darwin
+
+package open
+
+func inChroot(requests requests) results {
+	return results{Err: "open-in-chroot not available on this platform"}
+}

--- a/vendor/github.com/containers/buildah/internal/parse/parse.go
+++ b/vendor/github.com/containers/buildah/internal/parse/parse.go
@@ -8,15 +8,21 @@ import (
 	"strconv"
 	"strings"
 
+        "github.com/containers/buildah/copier"
 	"github.com/containers/buildah/internal"
 	internalUtil "github.com/containers/buildah/internal/util"
+	internalVolumes "github.com/containers/buildah/internal/volumes"
+	"github.com/containers/buildah/pkg/overlay"
 	"github.com/containers/common/pkg/parse"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
+	"github.com/containers/storage/pkg/mount"
+	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -41,16 +47,84 @@ var (
 	errDuplicateDest = errors.New("duplicate mount destination")
 )
 
+func mountIsReadWrite(m specs.Mount) bool {
+	// in case of conflicts, the last one wins, so it's not enough
+	// to check for the presence of either "rw" or "ro" anywhere
+	// with e.g. slices.Contains()
+	rw := true
+	for _, option := range m.Options {
+		switch option {
+		case "rw":
+			rw = true
+		case "ro":
+			rw = false
+		}
+	}
+	return rw
+}
+
+func convertToOverlay(m specs.Mount, store storage.Store, mountLabel, tmpDir string, uid, gid int) (specs.Mount, string, error) {
+	overlayDir, err := overlay.TempDir(tmpDir, uid, gid)
+	if err != nil {
+		return specs.Mount{}, "", fmt.Errorf("setting up overlay for %q: %w", m.Destination, err)
+	}
+	graphOptions := store.GraphOptions()
+	graphOptsCopy := make([]string, len(graphOptions))
+	copy(graphOptsCopy, graphOptions)
+	options := overlay.Options{GraphOpts: graphOptsCopy, ForceMount: true, MountLabel: mountLabel}
+	fileInfo, err := os.Stat(m.Source)
+	if err != nil {
+		return specs.Mount{}, "", fmt.Errorf("setting up overlay of %q: %w", m.Source, err)
+	}
+	// we might be trying to "overlay" for a non-directory, and the kernel doesn't like that very much
+	var mountThisInstead specs.Mount
+	if fileInfo.IsDir() {
+		// do the normal thing of mounting this directory as a lower with a temporary upper
+		mountThisInstead, err = overlay.MountWithOptions(overlayDir, m.Source, m.Destination, &options)
+		if err != nil {
+			return specs.Mount{}, "", fmt.Errorf("setting up overlay of %q: %w", m.Source, err)
+		}
+	} else {
+		// mount the parent directory as the lower with a temporary upper, and return a
+		// bind mount from the non-directory in the merged directory to the destination
+		sourceDir := filepath.Dir(m.Source)
+		sourceBase := filepath.Base(m.Source)
+		destination := m.Destination
+		mountedOverlay, err := overlay.MountWithOptions(overlayDir, sourceDir, destination, &options)
+		if err != nil {
+			return specs.Mount{}, "", fmt.Errorf("setting up overlay of %q: %w", sourceDir, err)
+		}
+		if mountedOverlay.Type != TypeBind {
+			if err2 := overlay.RemoveTemp(overlayDir); err2 != nil {
+				return specs.Mount{}, "", fmt.Errorf("cleaning up after failing to set up overlay: %v, while setting up overlay for %q: %w", err2, destination, err)
+			}
+			return specs.Mount{}, "", fmt.Errorf("setting up overlay for %q at %q: %w", mountedOverlay.Source, destination, err)
+		}
+		mountThisInstead = mountedOverlay
+		mountThisInstead.Source = filepath.Join(mountedOverlay.Source, sourceBase)
+		mountThisInstead.Destination = destination
+	}
+	return mountThisInstead, overlayDir, nil
+}
+
 // GetBindMount parses a single bind mount entry from the --mount flag.
-// Returns specifiedMount and a string which contains name of image that we mounted otherwise its empty.
-// Caller is expected to perform unmount of any mounted images
-func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, store storage.Store, imageMountLabel string, additionalMountPoints map[string]internal.StageMountDetails) (specs.Mount, string, error) {
+//
+// Returns a Mount to add to the runtime spec's list of mounts, the ID of the
+// image we mounted if we mounted one, the path of a mounted location if one
+// needs to be unmounted and removed, and the path of an overlay mount if one
+// needs to be cleaned up, or an error.
+//
+// The caller is expected to, after the command which uses the mount exits,
+// clean up the overlay filesystem (if we provided a path to it), unmount and
+// remove the mountpoint for the mounted filesystem (if we provided the path to
+// its mountpoint), and then unmount the image (if we mounted one).
+func GetBindMount(sys *types.SystemContext, args []string, contextDir string, store storage.Store, mountLabel string, additionalMountPoints map[string]internal.StageMountDetails, tmpDir string) (specs.Mount, string, string, string, error) {
 	newMount := specs.Mount{
 		Type: TypeBind,
 	}
 
-	mountReadability := false
-	setDest := false
+	mountReadability := ""
+	setDest := ""
 	bindNonRecursive := false
 	fromImage := ""
 
@@ -60,60 +134,59 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 		case "bind-nonrecursive":
 			newMount.Options = append(newMount.Options, "bind")
 			bindNonRecursive = true
-		case "ro", "nosuid", "nodev", "noexec":
+		case "nosuid", "nodev", "noexec":
 			// TODO: detect duplication of these options.
 			// (Is this necessary?)
 			newMount.Options = append(newMount.Options, kv[0])
-			mountReadability = true
 		case "rw", "readwrite":
 			newMount.Options = append(newMount.Options, "rw")
-			mountReadability = true
-		case "readonly":
-			// Alias for "ro"
+			mountReadability = "rw"
+		case "ro", "readonly":
 			newMount.Options = append(newMount.Options, "ro")
-			mountReadability = true
+			mountReadability = "ro"
 		case "shared", "rshared", "private", "rprivate", "slave", "rslave", "Z", "z", "U":
 			newMount.Options = append(newMount.Options, kv[0])
 		case "from":
 			if len(kv) == 1 {
-				return newMount, "", errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", "", "", errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			fromImage = kv[1]
 		case "bind-propagation":
 			if len(kv) == 1 {
-				return newMount, "", errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", "", "", errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			newMount.Options = append(newMount.Options, kv[1])
 		case "src", "source":
 			if len(kv) == 1 {
-				return newMount, "", errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", "", "", errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			newMount.Source = kv[1]
 		case "target", "dst", "destination":
 			if len(kv) == 1 {
-				return newMount, "", errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", "", "", errors.Wrapf(errBadOptionArg, kv[0])
 			}
+			setDest = kv[1]
 			if err := parse.ValidateVolumeCtrDir(kv[1]); err != nil {
-				return newMount, "", err
+				return newMount, "", "", "", err
 			}
 			newMount.Destination = kv[1]
-			setDest = true
 		case "consistency":
 			// Option for OS X only, has no meaning on other platforms
 			// and can thus be safely ignored.
 			// See also the handling of the equivalent "delegated" and "cached" in ValidateVolumeOpts
 		default:
-			return newMount, "", errors.Wrapf(errBadMntOption, kv[0])
+			return newMount, "", "", "", errors.Wrapf(errBadMntOption, kv[0])
 		}
 	}
 
 	// default mount readability is always readonly
-	if !mountReadability {
+	if mountReadability == "" {
 		newMount.Options = append(newMount.Options, "ro")
 	}
 
 	// Following variable ensures that we return imagename only if we did additional mount
-	isImageMounted := false
+	succeeded := false
+	mountedImage := ""
 	if fromImage != "" {
 		mountPoint := ""
 		if additionalMountPoints != nil {
@@ -124,16 +197,23 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 		// if mountPoint of image was not found in additionalMap
 		// or additionalMap was nil, try mounting image
 		if mountPoint == "" {
-			image, err := internalUtil.LookupImage(ctx, store, fromImage)
+			image, err := internalUtil.LookupImage(sys, store, fromImage)
 			if err != nil {
-				return newMount, "", err
+				return newMount, "", "", "", err
 			}
 
-			mountPoint, err = image.Mount(context.Background(), nil, imageMountLabel)
+			mountPoint, err = image.Mount(context.Background(), nil, mountLabel)
 			if err != nil {
-				return newMount, "", err
+				return newMount, "", "", "", err
 			}
-			isImageMounted = true
+			mountedImage = image.ID()
+			defer func() {
+				if !succeeded {
+					if _, err := store.UnmountImage(mountedImage, false); err != nil {
+						logrus.Debugf("unmounting bind-mounted image %q: %v", fromImage, err)
+					}
+				}
+			}()
 		}
 		contextDir = mountPoint
 	}
@@ -144,42 +224,74 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 		newMount.Options = append(newMount.Options, "rbind")
 	}
 
-	if !setDest {
-		return newMount, fromImage, errBadVolDest
+	if setDest == "" {
+		return newMount, "", "", "", errBadVolDest
 	}
 
 	// buildkit parity: support absolute path for sources from current build context
 	if contextDir != "" {
 		// path should be /contextDir/specified path
-		newMount.Source = filepath.Join(contextDir, filepath.Clean(string(filepath.Separator)+newMount.Source))
+                evaluated, err := copier.Eval(contextDir, contextDir+string(filepath.Separator)+newMount.Source, copier.EvalOptions{})
+                if err != nil {
+                    return newMount, "", "", "", err
+                }
+                newMount.Source = evaluated
 	} else {
 		// looks like its coming from `build run --mount=type=bind` allow using absolute path
 		// error out if no source is set
 		if newMount.Source == "" {
-			return newMount, "", errBadVolSrc
+			return newMount, "", "", "", errBadVolSrc
 		}
 		if err := parse.ValidateVolumeHostDir(newMount.Source); err != nil {
-			return newMount, "", err
+			return newMount, "", "", "", err
 		}
 	}
 
 	opts, err := parse.ValidateVolumeOpts(newMount.Options)
 	if err != nil {
-		return newMount, fromImage, err
+		return newMount, "", "", "", err
 	}
 	newMount.Options = opts
 
-	if !isImageMounted {
-		// we don't want any cleanups if image was not mounted explicitly
-		// so dont return anything
-		fromImage = ""
+	var intermediateMount string
+	if contextDir != "" && newMount.Source != contextDir {
+		rel, err := filepath.Rel(contextDir, newMount.Source)
+		if err != nil {
+			return newMount, "", "", "", fmt.Errorf("computing pathname of bind subdirectory: %w", err)
+		}
+		if rel != "." && rel != "/" {
+			mnt, err := internalVolumes.BindFromChroot(contextDir, rel, tmpDir)
+			if err != nil {
+				return newMount, "", "", "", fmt.Errorf("sanitizing bind subdirectory %q: %w", newMount.Source, err)
+			}
+			logrus.Debugf("bind-mounted %q under %q to %q", rel, contextDir, mnt)
+			intermediateMount = mnt
+			newMount.Source = intermediateMount
+		}
 	}
 
-	return newMount, fromImage, nil
+	overlayDir := ""
+	if mountedImage != "" || mountIsReadWrite(newMount) {
+		if newMount, overlayDir, err = convertToOverlay(newMount, store, mountLabel, tmpDir, 0, 0); err != nil {
+			return newMount, "", "", "", err
+		}
+	}
+
+	succeeded = true
+
+	return newMount, mountedImage, intermediateMount, overlayDir, nil
 }
 
 // GetCacheMount parses a single cache mount entry from the --mount flag.
-func GetCacheMount(args []string, store storage.Store, imageMountLabel string, additionalMountPoints map[string]internal.StageMountDetails) (specs.Mount, []string, error) {
+//
+// Returns a Mount to add to the runtime spec's list of mounts, the path of a
+// mounted filesystem if one needs to be unmounted, and an optional lock that
+// needs to be released, or an error.
+//
+// The caller is expected to, after the command which uses the mount exits,
+// unmount and remove the mountpoint of the mounted filesystem (if we provided
+// the path to its mountpoint).
+func GetCacheMount(args []string, additionalMountPoints map[string]internal.StageMountDetails, tmpDir string) (specs.Mount, string, []string, error) {
 	var err error
 	var mode uint64
 	lockedTargets := make([]string, 0)
@@ -223,73 +335,75 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 			sharing = kv[1]
 		case "bind-propagation":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", nil, errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			newMount.Options = append(newMount.Options, kv[1])
 		case "id":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", nil, errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			id = kv[1]
 		case "from":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", nil, errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			fromStage = kv[1]
 		case "target", "dst", "destination":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", nil, errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			if err := parse.ValidateVolumeCtrDir(kv[1]); err != nil {
-				return newMount, lockedTargets, err
+				return newMount, "", nil, err
 			}
 			newMount.Destination = kv[1]
 			setDest = true
 		case "src", "source":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", nil, errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			newMount.Source = kv[1]
 		case "mode":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", nil, errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			mode, err = strconv.ParseUint(kv[1], 8, 32)
 			if err != nil {
-				return newMount, lockedTargets, errors.Wrapf(err, "Unable to parse cache mode")
+				return newMount, "", nil, errors.Wrapf(err, "Unable to parse cache mode")
 			}
 		case "uid":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", nil, errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			uid, err = strconv.Atoi(kv[1])
 			if err != nil {
-				return newMount, lockedTargets, errors.Wrapf(err, "Unable to parse cache uid")
+				return newMount, "", nil, errors.Wrapf(err, "Unable to parse cache uid")
 			}
 		case "gid":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", nil, errors.Wrapf(errBadOptionArg, kv[0])
 			}
 			gid, err = strconv.Atoi(kv[1])
 			if err != nil {
-				return newMount, lockedTargets, errors.Wrapf(err, "Unable to parse cache gid")
+				return newMount, "", nil, errors.Wrapf(err, "Unable to parse cache gid")
 			}
 		default:
-			return newMount, lockedTargets, errors.Wrapf(errBadMntOption, kv[0])
+			return newMount, "", nil, errors.Wrapf(errBadMntOption, kv[0])
 		}
 	}
 
 	if !setDest {
-		return newMount, lockedTargets, errBadVolDest
+		return newMount, "", nil, errBadVolDest
 	}
 
+	thisCacheRoot := ""
 	if fromStage != "" {
-		// do not create cache on host
-		// instead use read-only mounted stage as cache
+		// do not create and use a cache direcotry on the host,
+		// instead use the location in the mounted stage or
+		// temporary directory as the cache
 		mountPoint := ""
 		if additionalMountPoints != nil {
 			if val, ok := additionalMountPoints[fromStage]; ok {
-				if val.IsStage {
+				if !val.IsImage {
 					mountPoint = val.MountPoint
 				}
 			}
@@ -297,10 +411,9 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// Cache does not supports using image so if not stage found
 		// return with error
 		if mountPoint == "" {
-			return newMount, lockedTargets, fmt.Errorf("no stage found with name %s", fromStage)
+			return newMount, "", nil, fmt.Errorf("no stage or additional build context found with name %s", fromStage)
 		}
-		// path should be /contextDir/specified path
-		newMount.Source = filepath.Join(mountPoint, filepath.Clean(string(filepath.Separator)+newMount.Source))
+		thisCacheRoot = mountPoint
 	} else {
 		// we need to create cache on host if no image is being used
 
@@ -313,41 +426,58 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// create cache on host if not present
 		err = os.MkdirAll(cacheParent, os.FileMode(0755))
 		if err != nil {
-			return newMount, lockedTargets, errors.Wrapf(err, "Unable to create build cache directory")
+			return newMount, "", nil, errors.Wrapf(err, "Unable to create build cache directory")
 		}
 
 		if id != "" {
-			newMount.Source = filepath.Join(cacheParent, filepath.Clean(id))
+			// Don't let the user control where we place the directory.
+			dirID := digest.FromString(id).Encoded()[:16]
+			thisCacheRoot = filepath.Join(cacheParent, dirID)
 		} else {
-			newMount.Source = filepath.Join(cacheParent, filepath.Clean(newMount.Destination))
+			// Don't let the user control where we place the directory.
+			dirID := digest.FromString(newMount.Destination).Encoded()[:16]
+			thisCacheRoot = filepath.Join(cacheParent, dirID)
 		}
 		idPair := idtools.IDPair{
 			UID: uid,
 			GID: gid,
 		}
-		//buildkit parity: change uid and gid if specified otheriwise keep `0`
-		err = idtools.MkdirAllAndChownNew(newMount.Source, os.FileMode(mode), idPair)
+		// buildkit parity: change uid and gid if specified otheriwise keep `0`
+		err = idtools.MkdirAllAndChownNew(thisCacheRoot, os.FileMode(mode), idPair)
 		if err != nil {
-			return newMount, lockedTargets, errors.Wrapf(err, "Unable to change uid,gid of cache directory")
+			return newMount, "", nil, errors.Wrapf(err, "Unable to change uid,gid of cache directory")
 		}
 	}
 
+	// path should be /mountPoint/specified path
+	evaluated, err := copier.Eval(thisCacheRoot, thisCacheRoot+string(filepath.Separator)+newMount.Source, copier.EvalOptions{})
+	if err != nil {
+		return newMount, "", nil, err
+	}
+	newMount.Source = evaluated
+
+	succeeded := false
 	switch sharing {
 	case "locked":
 		// lock parent cache
 		lockfile, err := lockfile.GetLockfile(filepath.Join(newMount.Source, BuildahCacheLockfile))
 		if err != nil {
-			return newMount, lockedTargets, errors.Wrapf(err, "Unable to acquire lock when sharing mode is locked")
+			return newMount, "", nil, errors.Wrapf(err, "Unable to acquire lock when sharing mode is locked")
 		}
 		// Will be unlocked after the RUN step is executed.
 		lockfile.Lock()
 		lockedTargets = append(lockedTargets, filepath.Join(newMount.Source, BuildahCacheLockfile))
+		defer func() {
+			if !succeeded {
+				UnlockLockArray(lockedTargets)
+			}
+		}()
 	case "shared":
 		// do nothing since default is `shared`
 		break
 	default:
 		// error out for unknown values
-		return newMount, lockedTargets, errors.Wrapf(err, "Unrecognized value %q for field `sharing`", sharing)
+		return newMount, "", nil, errors.Wrapf(err, "Unrecognized value %q for field `sharing`", sharing)
 	}
 
 	// buildkit parity: default sharing should be shared
@@ -365,11 +495,29 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 
 	opts, err := parse.ValidateVolumeOpts(newMount.Options)
 	if err != nil {
-		return newMount, lockedTargets, err
+		return newMount, "", nil, err
 	}
 	newMount.Options = opts
 
-	return newMount, lockedTargets, nil
+	var intermediateMount string
+	if newMount.Source != thisCacheRoot {
+		rel, err := filepath.Rel(thisCacheRoot, newMount.Source)
+		if err != nil {
+			return newMount, "", nil, fmt.Errorf("computing pathname of cache subdirectory: %w", err)
+		}
+		if rel != "." && rel != "/" {
+			mnt, err := internalVolumes.BindFromChroot(thisCacheRoot, rel, tmpDir)
+			if err != nil {
+				return newMount, "", nil, fmt.Errorf("sanitizing cache subdirectory %q: %w", newMount.Source, err)
+			}
+			logrus.Debugf("bind-mounted %q under %q to %q", rel, thisCacheRoot, mnt)
+			intermediateMount = mnt
+			newMount.Source = intermediateMount
+		}
+	}
+
+	succeeded = true
+	return newMount, intermediateMount, lockedTargets, nil
 }
 
 // ValidateVolumeMountHostDir validates the host path of buildah --volume
@@ -456,19 +604,52 @@ func Volume(volume string) (specs.Mount, error) {
 	return mount, nil
 }
 
-// GetVolumes gets the volumes from --volume and --mount
-func GetVolumes(ctx *types.SystemContext, store storage.Store, volumes []string, mounts []string, contextDir string) ([]specs.Mount, []string, []string, error) {
-	unifiedMounts, mountedImages, lockedTargets, err := getMounts(ctx, store, mounts, contextDir)
+// GetVolumes gets the volumes from --volume and --mount flags.
+//
+// Returns a slice of Mounts to add to the runtime spec's list of mounts, the
+// IDs of any images we mounted, a slice of bind-mounted paths, a slice of
+// overlay directories and a slice of locks that we acquired, or an error.
+//
+// The caller is expected to, after the command which uses the mounts and
+// volumes exits, clean up the overlay directories, unmount and remove the
+// mountpoints for the bind-mounted paths, unmount any images we mounted, and
+// release the locks we returned if any.
+func GetVolumes(ctx *types.SystemContext, store storage.Store, mountLabel string, volumes []string, mounts []string, contextDir string, tmpDir string) ([]specs.Mount, []string, []string, []string, []string, error) {
+	unifiedMounts, mountedImages, intermediateMounts, overlayMounts, lockedTargets, err := getMounts(ctx, store, mountLabel, mounts, contextDir, tmpDir)
 	if err != nil {
-		return nil, mountedImages, lockedTargets, err
+		return nil, nil, nil, nil, nil, err
 	}
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			for _, overlayMount := range overlayMounts {
+				if err := overlay.RemoveTemp(overlayMount); err != nil {
+					logrus.Debugf("unmounting overlay mount at %q: %v", overlayMount, err)
+				}
+			}
+			for _, intermediateMount := range intermediateMounts {
+				if err := mount.Unmount(intermediateMount); err != nil {
+					logrus.Debugf("unmounting intermediate mount point %q: %v", intermediateMount, err)
+				}
+				if err := os.Remove(intermediateMount); err != nil {
+					logrus.Debugf("removing should-be-empty directory %q: %v", intermediateMount, err)
+				}
+			}
+			for _, image := range mountedImages {
+				if _, err := store.UnmountImage(image, false); err != nil {
+					logrus.Debugf("unmounting image %q: %v", image, err)
+				}
+			}
+			UnlockLockArray(lockedTargets)
+		}
+	}()
 	volumeMounts, err := getVolumeMounts(volumes)
 	if err != nil {
-		return nil, mountedImages, lockedTargets, err
+		return nil, nil, nil, nil, nil, err
 	}
 	for dest, mount := range volumeMounts {
 		if _, ok := unifiedMounts[dest]; ok {
-			return nil, mountedImages, lockedTargets, errors.Wrapf(errDuplicateDest, dest)
+			return nil, nil, nil, nil, nil, errors.Wrapf(errDuplicateDest, dest)
 		}
 		unifiedMounts[dest] = mount
 	}
@@ -477,17 +658,54 @@ func GetVolumes(ctx *types.SystemContext, store storage.Store, volumes []string,
 	for _, mount := range unifiedMounts {
 		finalMounts = append(finalMounts, mount)
 	}
-	return finalMounts, mountedImages, lockedTargets, nil
+	succeeded = true
+	return finalMounts, mountedImages, intermediateMounts, overlayMounts, lockedTargets, nil
 }
 
-// getMounts takes user-provided input from the --mount flag and creates OCI
-// spec mounts.
-// buildah run --mount type=bind,src=/etc/resolv.conf,target=/etc/resolv.conf ...
-// buildah run --mount type=tmpfs,target=/dev/shm ...
-func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, contextDir string) (map[string]specs.Mount, []string, []string, error) {
-	finalMounts := make(map[string]specs.Mount)
-	mountedImages := make([]string, 0)
-	lockedTargets := make([]string, 0)
+// getMounts takes user-provided inputs from the --mount flag and returns a
+// slice of OCI spec mounts, a slice of mounted image IDs, a slice of other
+// mount locations, a slice of overlay mounts, and a slice of locks, or an
+// error.
+//
+//     buildah run --mount type=bind,src=/etc/resolv.conf,target=/etc/resolv.conf ...
+//     buildah run --mount type=cache,target=/var/cache ...
+//     buildah run --mount type=tmpfs,target=/dev/shm ...
+//
+// The caller is expected to, after the command which uses the mounts exits,
+// unmount the overlay filesystems (if we mounted any), unmount the other
+// mounted filesystems and remove their mountpoints (if we provided any paths
+// to mountpoints), unmount any mounted images (if we provided the IDs of any),
+// and then unlock the locks we returned if any.
+func getMounts(ctx *types.SystemContext, store storage.Store, mountLabel string, mounts []string, contextDir, tmpDir string) (map[string]specs.Mount, []string, []string, []string, []string, error) {
+	finalMounts := make(map[string]specs.Mount, len(mounts))
+	mountedImages := make([]string, 0, len(mounts))
+	intermediateMounts := make([]string, 0, len(mounts))
+	overlayMounts := make([]string, 0, len(mounts))
+	lockedTargets := make([]string, 0, len(mounts))
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			for _, overlayDir := range overlayMounts {
+				if err := overlay.RemoveTemp(overlayDir); err != nil {
+					logrus.Debugf("unmounting overlay mount at %q: %v", overlayDir, err)
+				}
+			}
+			for _, intermediateMount := range intermediateMounts {
+				if err := mount.Unmount(intermediateMount); err != nil {
+					logrus.Debugf("unmounting intermediate mount point %q: %v", intermediateMount, err)
+				}
+				if err := os.Remove(intermediateMount); err != nil {
+					logrus.Debugf("removing should-be-empty directory %q: %v", intermediateMount, err)
+				}
+			}
+			for _, image := range mountedImages {
+				if _, err := store.UnmountImage(image, false); err != nil {
+					logrus.Debugf("unmounting image %q: %v", image, err)
+				}
+			}
+			UnlockLockArray(lockedTargets)
+		}
+	}()
 
 	errInvalidSyntax := errors.Errorf("incorrect mount format: should be --mount type=<bind|tmpfs>,[src=<host-dir>,]target=<ctr-dir>[,options]")
 
@@ -497,52 +715,64 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 	for _, mount := range mounts {
 		arr := strings.SplitN(mount, ",", 2)
 		if len(arr) < 2 {
-			return nil, mountedImages, lockedTargets, errors.Wrapf(errInvalidSyntax, "%q", mount)
+			return nil, nil, nil, nil, nil, errors.Wrapf(errInvalidSyntax, "%q", mount)
 		}
 		kv := strings.Split(arr[0], "=")
 		// TODO: type is not explicitly required in Docker.
 		// If not specified, it defaults to "volume".
 		if len(kv) != 2 || kv[0] != "type" {
-			return nil, mountedImages, lockedTargets, errors.Wrapf(errInvalidSyntax, "%q", mount)
+			return nil, nil, nil, nil, nil, errors.Wrapf(errInvalidSyntax, "%q", mount)
 		}
 
 		tokens := strings.Split(arr[1], ",")
 		switch kv[1] {
 		case TypeBind:
-			mount, image, err := GetBindMount(ctx, tokens, contextDir, store, "", nil)
+			mount, image, intermediateMount, overlayMount, err := GetBindMount(ctx, tokens, contextDir, store, mountLabel, nil, tmpDir)
 			if err != nil {
-				return nil, mountedImages, lockedTargets, err
+				return nil, nil, nil, nil, nil, err
+			}
+			if image != "" {
+				mountedImages = append(mountedImages, image)
+			}
+			if intermediateMount != "" {
+				intermediateMounts = append(intermediateMounts, intermediateMount)
+			}
+			if overlayMount != "" {
+				overlayMounts = append(overlayMounts, overlayMount)
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, errors.Wrapf(errDuplicateDest, mount.Destination)
+				return nil, nil, nil, nil, nil, errors.Wrapf(errDuplicateDest, mount.Destination)
 			}
 			finalMounts[mount.Destination] = mount
-			mountedImages = append(mountedImages, image)
 		case TypeCache:
-			mount, lockedPaths, err := GetCacheMount(tokens, store, "", nil)
-			lockedTargets = lockedPaths
+			mount, intermediateMount, lockedPaths, err := GetCacheMount(tokens, nil, tmpDir)
+			lockedTargets = append(lockedTargets, lockedPaths...)
 			if err != nil {
-				return nil, mountedImages, lockedTargets, err
+				return nil, nil, nil, nil, nil, err
+			}
+			if intermediateMount != "" {
+				intermediateMounts = append(intermediateMounts, intermediateMount)
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, errors.Wrapf(errDuplicateDest, mount.Destination)
+				return nil, nil, nil, nil, nil, errors.Wrapf(errDuplicateDest, mount.Destination)
 			}
 			finalMounts[mount.Destination] = mount
 		case TypeTmpfs:
 			mount, err := GetTmpfsMount(tokens)
 			if err != nil {
-				return nil, mountedImages, lockedTargets, err
+				return nil, nil, nil, nil, nil, err
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, errors.Wrapf(errDuplicateDest, mount.Destination)
+				return nil, nil, nil, nil, nil, errors.Wrapf(errDuplicateDest, mount.Destination)
 			}
 			finalMounts[mount.Destination] = mount
 		default:
-			return nil, mountedImages, lockedTargets, errors.Errorf("invalid filesystem type %q", kv[1])
+			return nil, nil, nil, nil, nil, errors.Errorf("invalid filesystem type %q", kv[1])
 		}
 	}
 
-	return finalMounts, mountedImages, lockedTargets, nil
+	succeeded = true
+	return finalMounts, mountedImages, intermediateMounts, overlayMounts, lockedTargets, nil
 }
 
 // GetTmpfsMount parses a single tmpfs mount entry from the --mount flag
@@ -596,4 +826,32 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 	}
 
 	return newMount, nil
+}
+
+func UnlockLockArray(lockedTargets []string) {
+	for _, path := range lockedTargets {
+		_, err := os.Stat(path)
+		if err != nil {
+			// Lockfile not found this might be a problem,
+			// since LockedTargets must contain list of all locked files
+			// don't break here since we need to unlock other files but
+			// log so user can take a look
+			logrus.Warnf("Lockfile %q was expected here, stat failed with %v", path, err)
+			continue
+		}
+		lockfile, err := lockfile.GetLockfile(path)
+		if err != nil {
+			// unable to get lockfile
+			// lets log error and continue
+			// unlocking other files
+			logrus.Warn(err)
+			continue
+		}
+		if lockfile.Locked() {
+			lockfile.Unlock()
+		} else {
+			logrus.Warnf("Lockfile %q was expected to be locked, this is unexpected", path)
+			continue
+		}
+	}
 }

--- a/vendor/github.com/containers/buildah/internal/types.go
+++ b/vendor/github.com/containers/buildah/internal/types.go
@@ -12,6 +12,8 @@ const (
 // StageExecutor has ability to mount stages/images in current context and
 // automatically clean them up.
 type StageMountDetails struct {
-	IsStage    bool   // tells if mountpoint returned from stage executor is stage or image
-	MountPoint string // mountpoint of stage/image
+	IsStage                  bool   // true if the mountpoint is a stage's rootfs
+	IsImage                  bool   // true if the mountpoint is an image's rootfs
+	IsAdditionalBuildContext bool   // true if the mountpoint is an additional build context
+	MountPoint               string // mountpoint of stage/image or image's root directory or path of the additional build context
 }

--- a/vendor/github.com/containers/buildah/internal/volumes/bind_linux.go
+++ b/vendor/github.com/containers/buildah/internal/volumes/bind_linux.go
@@ -1,0 +1,102 @@
+package volumes
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/containers/buildah/internal/open"
+	"github.com/containers/storage/pkg/mount"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// BindFromChroot opens "path" inside of "root" using a chrooted subprocess
+// that returns a descriptor, then creates a uniquely-named temporary directory
+// or file under "tmp" and bind-mounts the opened descriptor to it, returning
+// the path of the temporary file or directory.  The caller is responsible for
+// unmounting and removing the temporary.
+func BindFromChroot(root, path, tmp string) (string, error) {
+	fd, _, err := open.InChroot(root, "", path, unix.O_DIRECTORY|unix.O_RDONLY, 0)
+	if err != nil {
+		if !errors.Is(err, unix.ENOTDIR) {
+			return "", fmt.Errorf("opening directory %q under %q: %w", path, root, err)
+		}
+		fd, _, err = open.InChroot(root, "", path, unix.O_RDWR, 0)
+		if err != nil {
+			return "", fmt.Errorf("opening non-directory %q under %q: %w", path, root, err)
+		}
+	}
+	defer func() {
+		if err := unix.Close(fd); err != nil {
+			logrus.Debugf("closing %q under %q: %v", path, root, err)
+		}
+	}()
+
+	succeeded := false
+	var dest string
+	var destF *os.File
+	defer func() {
+		if !succeeded {
+			if destF != nil {
+				if err := destF.Close(); err != nil {
+					logrus.Debugf("closing bind target %q: %v", dest, err)
+				}
+			}
+			if dest != "" {
+				if err := os.Remove(dest); err != nil {
+					logrus.Debugf("removing bind target %q: %v", dest, err)
+				}
+			}
+		}
+	}()
+
+	var st unix.Stat_t
+	if err = unix.Fstat(fd, &st); err != nil {
+		return "", fmt.Errorf("checking if %q under %q was a directory: %w", path, root, err)
+	}
+
+	if st.Mode&unix.S_IFDIR == unix.S_IFDIR {
+		if dest, err = os.MkdirTemp(tmp, "bind"); err != nil {
+			return "", fmt.Errorf("creating a bind target directory: %w", err)
+		}
+	} else {
+		if destF, err = os.CreateTemp(tmp, "bind"); err != nil {
+			return "", fmt.Errorf("creating a bind target non-directory: %w", err)
+		}
+		if err := destF.Close(); err != nil {
+			logrus.Debugf("closing bind target %q: %v", dest, err)
+		}
+		dest = destF.Name()
+	}
+	defer func() {
+		if !succeeded {
+			if err := os.Remove(dest); err != nil {
+				logrus.Debugf("removing bind target %q: %v", dest, err)
+			}
+		}
+	}()
+
+	if err := unix.Mount(fmt.Sprintf("/proc/self/fd/%d", fd), dest, "bind", unix.MS_BIND, ""); err != nil {
+		return "", fmt.Errorf("bind-mounting passed-in descriptor to %q: %w", dest, err)
+	}
+	defer func() {
+		if !succeeded {
+			if err := mount.Unmount(dest); err != nil {
+				logrus.Debugf("unmounting bound target %q: %v", dest, err)
+			}
+		}
+	}()
+
+	var st2 unix.Stat_t
+	if err = unix.Stat(dest, &st2); err != nil {
+		return "", fmt.Errorf("looking up device/inode of newly-bind-mounted %q: %w", dest, err)
+	}
+
+	if st2.Dev != st.Dev || st2.Ino != st.Ino {
+		return "", fmt.Errorf("device/inode weren't what we expected after bind mounting: %w", err)
+	}
+
+	succeeded = true
+	return dest, nil
+}

--- a/vendor/github.com/containers/buildah/internal/volumes/bind_notlinux.go
+++ b/vendor/github.com/containers/buildah/internal/volumes/bind_notlinux.go
@@ -1,0 +1,16 @@
+//go:build !linux
+// +build !linux
+
+package volumes
+
+import "errors"
+
+// BindFromChroot would open "path" inside of "root" using a chrooted
+// subprocess that returns a descriptor, then would create a uniquely-named
+// temporary directory or file under "tmp" and bind-mount the opened descriptor
+// to it, returning the path of the temporary file or directory.  The caller
+// would be responsible for unmounting and removing the temporary.  For now,
+// this just returns an error because it is not implemented for this platform.
+func BindFromChroot(root, path, tmp string) (string, error) {
+	return "", errors.New("not available on this system")
+}

--- a/vendor/github.com/containers/buildah/pkg/overlay/overlay.go
+++ b/vendor/github.com/containers/buildah/pkg/overlay/overlay.go
@@ -10,9 +10,11 @@ import (
 	"syscall"
 
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/system"
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -50,6 +52,12 @@ type Options struct {
 	RootUID int
 	// RootGID is not used yet but keeping it here for legacy reasons.
 	RootGID int
+	// Force overlay mounting and return a bind mount, rather than
+	// attempting to optimize by having the runtime actually mount and
+	// manage the overlay filesystem.
+	ForceMount bool
+	// MountLabel is a label to force for the overlay filesystem.
+	MountLabel string
 }
 
 // TempDir generates an overlay Temp directory in the container content
@@ -146,6 +154,12 @@ func mountWithMountProgram(mountProgram, overlayOptions, mergeDir string) error 
 	return nil
 }
 
+// mountNatively mounts an overlay at mergeDir using the kernel's mount()
+// system call.
+func mountNatively(overlayOptions, mergeDir string) error {
+	return mount.Mount("overlay", mergeDir, "overlay", overlayOptions)
+}
+
 // MountWithOptions creates a subdir of the contentDir based on the source directory
 // from the source system.  It then mounts up the source directory on to the
 // generated mount point and returns the mount point to the caller.
@@ -187,6 +201,9 @@ func MountWithOptions(contentDir, source, dest string, opts *Options) (mount spe
 		}
 		overlayOptions = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", escapeColon(source), upperDir, workDir)
 	}
+	if opts.MountLabel != "" {
+		overlayOptions = overlayOptions + "," + label.FormatMountLabel("", opts.MountLabel)
+	}
 
 	mountProgram := findMountProgram(opts.GraphOpts)
 	if mountProgram != "" {
@@ -210,6 +227,18 @@ func MountWithOptions(contentDir, source, dest string, opts *Options) (mount spe
 	mount.Destination = dest
 	mount.Type = "overlay"
 	mount.Options = strings.Split(overlayOptions, ",")
+
+	if opts.ForceMount {
+		if err := mountNatively(overlayOptions, mergeDir); err != nil {
+			return mount, err
+		}
+
+		mount.Source = mergeDir
+		mount.Destination = dest
+		mount.Type = "bind"
+		mount.Options = []string{"bind", "slave"}
+		return mount, nil
+	}
 
 	return mount, nil
 }

--- a/vendor/github.com/containers/buildah/run.go
+++ b/vendor/github.com/containers/buildah/run.go
@@ -165,16 +165,20 @@ type RunOptions struct {
 
 // RunMountArtifacts are the artifacts created when using a run mount.
 type runMountArtifacts struct {
-	// RunMountTargets are the run mount targets inside the container
+	// RunMountTargets are the run mount targets inside the container which should be removed
 	RunMountTargets []string
+	// RunOverlayDirs are overlay directories which will need to be cleaned up using overlay.RemoveTemp()
+	RunOverlayDirs []string
 	// TmpFiles are artifacts that need to be removed outside the container
 	TmpFiles []string
-	// Any external images which were mounted inside container
+	// Any images which were mounted, which should be unmounted
 	MountedImages []string
-	// Agents are the ssh agents started
+	// Agents are the ssh agents started, which should have their Shutdown() methods called
 	Agents []*sshagent.AgentServer
 	// SSHAuthSock is the path to the ssh auth sock inside the container
 	SSHAuthSock string
 	// LockedTargets to be unlocked if there are any.
 	LockedTargets []string
+	// Intermediate mount points, which should be Unmount()ed and Removed()d
+	IntermediateMounts []string
 }

--- a/vendor/github.com/containers/buildah/run_linux.go
+++ b/vendor/github.com/containers/buildah/run_linux.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
 	internalParse "github.com/containers/buildah/internal/parse"
-	internalUtil "github.com/containers/buildah/internal/util"
 	"github.com/containers/buildah/pkg/overlay"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/pkg/sshagent"
@@ -45,10 +44,10 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/lockfile"
+	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/containers/storage/pkg/unshare"
-	storagetypes "github.com/containers/storage/types"
 	"github.com/docker/go-units"
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/docker/libnetwork/types"
@@ -338,7 +337,7 @@ rootless=%d
 	}
 
 	defer func() {
-		if err := b.cleanupRunMounts(options.SystemContext, mountPoint, runArtifacts); err != nil {
+		if err := b.cleanupRunMounts(mountPoint, runArtifacts); err != nil {
 			options.Logger.Errorf("unable to cleanup run mounts %v", err)
 		}
 	}()
@@ -523,10 +522,18 @@ func (b *Builder) setupMounts(context *imagetypes.SystemContext, mountPoint stri
 
 	// Get the list of mounts that are just for this Run() call.
 	// TODO: acui: de-spaghettify run mounts
-	runMounts, mountArtifacts, err := b.runSetupRunMounts(context, runFileMounts, secrets, stageMountPoints, sshSources, cdir, contextDir, spec.Linux.UIDMappings, spec.Linux.GIDMappings, int(rootUID), int(rootGID), int(processUID), int(processGID))
+	runMounts, mountArtifacts, err := b.runSetupRunMounts(context, bundlePath, runFileMounts, secrets, stageMountPoints, sshSources, cdir, contextDir, spec.Linux.UIDMappings, spec.Linux.GIDMappings, int(rootUID), int(rootGID), int(processUID), int(processGID))
 	if err != nil {
 		return nil, err
 	}
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			if err := b.cleanupRunMounts(mountPoint, mountArtifacts); err != nil {
+				b.Logger.Debugf("cleaning up run mounts: %v", err)
+			}
+		}
+	}()
 	// Add temporary copies of the contents of volume locations at the
 	// volume locations, unless we already have something there.
 	builtins, err := runSetupBuiltinVolumes(b.MountLabel, mountPoint, cdir, builtinVolumes, int(rootUID), int(rootGID))
@@ -558,6 +565,7 @@ func (b *Builder) setupMounts(context *imagetypes.SystemContext, mountPoint stri
 
 	// Set the list in the spec.
 	spec.Mounts = mounts
+	succeeded = true
 	return mountArtifacts, nil
 }
 
@@ -1880,11 +1888,14 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 				return specs.Mount{}, errors.Wrapf(err, "failed to create TempDir in the %s directory", containerDir)
 			}
 
+			graphOptions := b.store.GraphOptions()
+			graphOptsCopy := make([]string, len(graphOptions))
+			copy(graphOptsCopy, graphOptions)
 			overlayOpts := overlay.Options{RootUID: rootUID,
 				RootGID:                rootGID,
 				UpperDirOptionFragment: upperDir,
 				WorkDirOptionFragment:  workDir,
-				GraphOpts:              b.store.GraphOptions(),
+				GraphOpts:              graphOptsCopy,
 			}
 
 			overlayMount, err := overlay.MountWithOptions(contentDir, host, container, &overlayOpts)
@@ -1893,7 +1904,7 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 			}
 
 			// If chown true, add correct ownership to the overlay temp directories.
-			if foundU {
+			if err == nil && foundU {
 				if err := chown.ChangeHostPathOwnership(contentDir, true, processUID, processGID); err != nil {
 					return specs.Mount{}, err
 				}
@@ -1955,6 +1966,7 @@ func setupMaskedPaths(g *generate.Generator) {
 		"/sys/firmware",
 		"/sys/fs/selinux",
 		"/sys/dev",
+		"/sys/devices/virtual/powercap",
 	} {
 		g.AddLinuxMaskedPaths(mp)
 	}
@@ -2513,17 +2525,55 @@ func init() {
 }
 
 // runSetupRunMounts sets up mounts that exist only in this RUN, not in subsequent runs
-func (b *Builder) runSetupRunMounts(context *imagetypes.SystemContext, mounts []string, secrets map[string]define.Secret, stageMountPoints map[string]internal.StageMountDetails, sshSources map[string]*sshagent.Source, containerWorkingDir string, contextDir string, uidmap []spec.LinuxIDMapping, gidmap []spec.LinuxIDMapping, rootUID int, rootGID int, processUID int, processGID int) ([]spec.Mount, *runMountArtifacts, error) {
-	mountTargets := make([]string, 0, 10)
+func (b *Builder) runSetupRunMounts(context *imagetypes.SystemContext, bundlePath string, mounts []string, secrets map[string]define.Secret, stageMountPoints map[string]internal.StageMountDetails, sshSources map[string]*sshagent.Source, containerWorkingDir string, contextDir string, uidmap []spec.LinuxIDMapping, gidmap []spec.LinuxIDMapping, rootUID int, rootGID int, processUID int, processGID int) ([]spec.Mount, *runMountArtifacts, error) {
+	mountTargets := make([]string, 0, len(mounts))
 	tmpFiles := make([]string, 0, len(mounts))
-	mountImages := make([]string, 0, 10)
+	mountImages := make([]string, 0, len(mounts))
+	intermediateMounts := make([]string, 0, len(mounts))
 	finalMounts := make([]specs.Mount, 0, len(mounts))
 	agents := make([]*sshagent.AgentServer, 0, len(mounts))
-	sshCount := 0
 	defaultSSHSock := ""
 	tokens := []string{}
 	lockedTargets := []string{}
+	var overlayDirs []string
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			for _, agent := range agents {
+				servePath := agent.ServePath()
+				if err := agent.Shutdown(); err != nil {
+					b.Logger.Errorf("shutting down SSH agent at %q: %v", servePath, err)
+				}
+			}
+			for _, overlayDir := range overlayDirs {
+				if err := overlay.RemoveTemp(overlayDir); err != nil {
+					b.Logger.Error(err.Error())
+				}
+			}
+			for _, intermediateMount := range intermediateMounts {
+				if err := mount.Unmount(intermediateMount); err != nil {
+					b.Logger.Errorf("unmounting %q: %v", intermediateMount, err)
+				}
+				if err := os.Remove(intermediateMount); err != nil {
+					b.Logger.Errorf("removing should-be-empty directory %q: %v", intermediateMount, err)
+				}
+			}
+			for _, mountImage := range mountImages {
+				if _, err := b.store.UnmountImage(mountImage, false); err != nil {
+					b.Logger.Error(err.Error())
+				}
+			}
+			for _, tmpFile := range tmpFiles {
+				if err := os.Remove(tmpFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+					b.Logger.Error(err.Error())
+				}
+			}
+			internalParse.UnlockLockArray(lockedTargets)
+		}
+	}()
 	for _, mount := range mounts {
+		var err error
+		var image, bundleMountsDir, overlayDir, intermediateMount string
 		arr := strings.SplitN(mount, ",", 2)
 
 		kv := strings.Split(arr[0], "=")
@@ -2548,31 +2598,40 @@ func (b *Builder) runSetupRunMounts(context *imagetypes.SystemContext, mounts []
 				}
 			}
 		case "ssh":
-			mount, agent, err := b.getSSHMount(tokens, sshCount, sshSources, b.MountLabel, uidmap, gidmap, b.ProcessLabel)
+			mount, agent, err := b.getSSHMount(tokens, len(agents), sshSources, b.MountLabel, uidmap, gidmap, b.ProcessLabel)
 			if err != nil {
 				return nil, nil, err
 			}
 			if mount != nil {
 				finalMounts = append(finalMounts, *mount)
 				mountTargets = append(mountTargets, mount.Destination)
-				agents = append(agents, agent)
-				if sshCount == 0 {
+				if len(agents) == 0 {
 					defaultSSHSock = mount.Destination
 				}
-				// Count is needed as the default destination of the ssh sock inside the container is  /run/buildkit/ssh_agent.{i}
-				sshCount++
+				agents = append(agents, agent)
 			}
 		case "bind":
-			mount, image, err := b.getBindMount(context, tokens, contextDir, rootUID, rootGID, processUID, processGID, stageMountPoints)
+			if bundleMountsDir == "" {
+				if bundleMountsDir, err = os.MkdirTemp(bundlePath, "mounts"); err != nil {
+					return nil, nil, err
+				}
+			}
+			var mount *spec.Mount
+			mount, image, intermediateMount, overlayDir, err = b.getBindMount(context, tokens, contextDir, rootUID, rootGID, processUID, processGID, stageMountPoints, bundleMountsDir)
 			if err != nil {
 				return nil, nil, err
 			}
-			finalMounts = append(finalMounts, *mount)
 			mountTargets = append(mountTargets, mount.Destination)
-			// only perform cleanup if image was mounted ignore everything else
 			if image != "" {
 				mountImages = append(mountImages, image)
 			}
+			if overlayDir != "" {
+				overlayDirs = append(overlayDirs, overlayDir)
+			}
+			if intermediateMount != "" {
+				intermediateMounts = append(intermediateMounts, intermediateMount)
+			}
+			finalMounts = append(finalMounts, *mount)
 		case "tmpfs":
 			mount, err := b.getTmpfsMount(tokens, rootUID, rootGID, processUID, processGID)
 			if err != nil {
@@ -2581,9 +2640,17 @@ func (b *Builder) runSetupRunMounts(context *imagetypes.SystemContext, mounts []
 			finalMounts = append(finalMounts, *mount)
 			mountTargets = append(mountTargets, mount.Destination)
 		case "cache":
-			mount, lockedPaths, err := b.getCacheMount(tokens, rootUID, rootGID, processUID, processGID, stageMountPoints)
+			if bundleMountsDir == "" {
+				if bundleMountsDir, err = os.MkdirTemp(bundlePath, "mounts"); err != nil {
+					return nil, nil, err
+				}
+			}
+			mount, intermediateMount, lockedPaths, err := b.getCacheMount(tokens, rootUID, rootGID, processUID, processGID, stageMountPoints, bundleMountsDir)
 			if err != nil {
 				return nil, nil, err
+			}
+			if intermediateMount != "" {
+				intermediateMounts = append(intermediateMounts, intermediateMount)
 			}
 			finalMounts = append(finalMounts, *mount)
 			mountTargets = append(mountTargets, mount.Destination)
@@ -2593,31 +2660,34 @@ func (b *Builder) runSetupRunMounts(context *imagetypes.SystemContext, mounts []
 		}
 	}
 	artifacts := &runMountArtifacts{
-		RunMountTargets: mountTargets,
-		TmpFiles:        tmpFiles,
-		Agents:          agents,
-		MountedImages:   mountImages,
-		SSHAuthSock:     defaultSSHSock,
-		LockedTargets:   lockedTargets,
+		RunMountTargets:    mountTargets,
+		RunOverlayDirs:     overlayDirs,
+		TmpFiles:           tmpFiles,
+		Agents:             agents,
+		MountedImages:      mountImages,
+		SSHAuthSock:        defaultSSHSock,
+		LockedTargets:      lockedTargets,
+		IntermediateMounts: intermediateMounts,
 	}
+	succeeded = true
 	return finalMounts, artifacts, nil
 }
 
-func (b *Builder) getBindMount(context *imagetypes.SystemContext, tokens []string, contextDir string, rootUID, rootGID, processUID, processGID int, stageMountPoints map[string]internal.StageMountDetails) (*spec.Mount, string, error) {
+func (b *Builder) getBindMount(sys *imagetypes.SystemContext, tokens []string, contextDir string, rootUID, rootGID, processUID, processGID int, stageMountPoints map[string]internal.StageMountDetails, tmpDir string) (*spec.Mount, string, string, string, error) {
 	if contextDir == "" {
-		return nil, "", errors.New("Context Directory for current run invocation is not configured")
+		return nil, "", "", "", errors.New("Context Directory for current run invocation is not configured")
 	}
 	var optionMounts []specs.Mount
-	mount, image, err := internalParse.GetBindMount(context, tokens, contextDir, b.store, b.MountLabel, stageMountPoints)
+	mount, image, intermediateMount, overlayMount, err := internalParse.GetBindMount(sys, tokens, contextDir, b.store, b.MountLabel, stageMountPoints, tmpDir)
 	if err != nil {
-		return nil, image, err
+		return nil, "", "", "", err
 	}
 	optionMounts = append(optionMounts, mount)
 	volumes, err := b.runSetupVolumeMounts(b.MountLabel, nil, optionMounts, rootUID, rootGID, processUID, processGID)
 	if err != nil {
-		return nil, image, err
+		return nil, "", "", "", err
 	}
-	return &volumes[0], image, nil
+	return &volumes[0], image, intermediateMount, overlayMount, nil
 }
 
 func (b *Builder) getTmpfsMount(tokens []string, rootUID, rootGID, processUID, processGID int) (*spec.Mount, error) {
@@ -2634,18 +2704,39 @@ func (b *Builder) getTmpfsMount(tokens []string, rootUID, rootGID, processUID, p
 	return &volumes[0], nil
 }
 
-func (b *Builder) getCacheMount(tokens []string, rootUID, rootGID, processUID, processGID int, stageMountPoints map[string]internal.StageMountDetails) (*spec.Mount, []string, error) {
+// Returns a Mount to add to the runtime spec's list of mounts, an optional
+// path of a mounted filesystem, unmounted, and an optional lock, or an error.
+//
+// The caller is expected to, after the command which uses the mount exits,
+// unmount the mounted filesystem (if we provided the path to its mountpoint)
+// and remove its mountpoint, , and release the lock (if we took one).
+func (b *Builder) getCacheMount(tokens []string, rootUID, rootGID, processUID, processGID int, stageMountPoints map[string]internal.StageMountDetails, tmpDir string) (*spec.Mount, string, []string, error) {
 	var optionMounts []specs.Mount
-	mount, lockedTargets, err := internalParse.GetCacheMount(tokens, b.store, b.MountLabel, stageMountPoints)
+	optionMount, intermediateMount, lockedTargets, err := internalParse.GetCacheMount(tokens, stageMountPoints, tmpDir)
 	if err != nil {
-		return nil, lockedTargets, err
+		return nil, "", nil, err
 	}
-	optionMounts = append(optionMounts, mount)
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			if intermediateMount != "" {
+				if err := mount.Unmount(intermediateMount); err != nil {
+					b.Logger.Debugf("unmounting %q: %v", intermediateMount, err)
+				}
+				if err := os.Remove(intermediateMount); err != nil {
+					b.Logger.Debugf("removing should-be-empty directory %q: %v", intermediateMount, err)
+				}
+			}
+			internalParse.UnlockLockArray(lockedTargets)
+		}
+	}()
+	optionMounts = append(optionMounts, optionMount)
 	volumes, err := b.runSetupVolumeMounts(b.MountLabel, nil, optionMounts, rootUID, rootGID, processUID, processGID)
 	if err != nil {
-		return nil, lockedTargets, err
+		return nil, "", nil, err
 	}
-	return &volumes[0], lockedTargets, nil
+	succeeded = true
+	return &volumes[0], intermediateMount, lockedTargets, nil
 }
 
 func getSecretMount(tokens []string, secrets map[string]define.Secret, mountlabel string, containerWorkingDir string, uidmap []spec.LinuxIDMapping, gidmap []spec.LinuxIDMapping) (*spec.Mount, string, error) {
@@ -2877,53 +2968,55 @@ func (b *Builder) getSSHMount(tokens []string, count int, sshsources map[string]
 }
 
 // cleanupRunMounts cleans up run mounts so they only appear in this run.
-func (b *Builder) cleanupRunMounts(context *imagetypes.SystemContext, mountpoint string, artifacts *runMountArtifacts) error {
+func (b *Builder) cleanupRunMounts(mountpoint string, artifacts *runMountArtifacts) error {
 	for _, agent := range artifacts.Agents {
-		err := agent.Shutdown()
-		if err != nil {
-			return err
+		servePath := agent.ServePath()
+		if err := agent.Shutdown(); err != nil {
+			return fmt.Errorf("shutting down SSH agent at %q: %v", servePath, err)
 		}
 	}
 
-	//cleanup any mounted images for this run
+	// clean up any overlays we mounted
+	for _, overlayDirectory := range artifacts.RunOverlayDirs {
+		if err := overlay.RemoveTemp(overlayDirectory); err != nil {
+			return err
+		}
+	}
+	// unmounting anything that needs unmounting
+	for _, intermediateMount := range artifacts.IntermediateMounts {
+		if err := mount.Unmount(intermediateMount); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("unmounting %q: %w", intermediateMount, err)
+		}
+		if err := os.Remove(intermediateMount); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("removing should-be-empty directory %q: %w", intermediateMount, err)
+		}
+	}
+	// unmount any images we mounted for this run
 	for _, image := range artifacts.MountedImages {
-		if image != "" {
-			// if flow hits here some image was mounted for this run
-			i, err := internalUtil.LookupImage(context, b.store, image)
-			if err == nil {
-				// silently try to unmount and do nothing
-				// if image is being used by something else
-				_ = i.Unmount(false)
-			}
-			if errors.Is(errors.Cause(err), storagetypes.ErrImageUnknown) {
-				// Ignore only if ErrImageUnknown
-				// Reason: Image is already unmounted do nothing
-				continue
-			}
-			return err
+		if _, err := b.store.UnmountImage(image, false); err != nil {
+			logrus.Debugf("unmounting image %q: %v", image, err)
 		}
 	}
 
+	// remove mount targets that were created for this run
 	opts := copier.RemoveOptions{
 		All: true,
 	}
 	for _, path := range artifacts.RunMountTargets {
-		err := copier.Remove(mountpoint, path, opts)
-		if err != nil {
-			return err
+		if err := copier.Remove(mountpoint, path, opts); err != nil {
+			return fmt.Errorf("removing mount target %q %q: %w", mountpoint, path, err)
 		}
 	}
 	var prevErr error
 	for _, path := range artifacts.TmpFiles {
-		err := os.Remove(path)
-		if !os.IsNotExist(err) {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			if prevErr != nil {
 				logrus.Error(prevErr)
 			}
-			prevErr = err
+			prevErr = fmt.Errorf("removing temporary file: %w", err)
 		}
 	}
-	// unlock if any locked files from this RUN statement
+	// unlock locks we took, most likely for cache mounts
 	for _, path := range artifacts.LockedTargets {
 		_, err := os.Stat(path)
 		if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -103,7 +103,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.1.1
 ## explicit; go 1.17
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.26.6
+# github.com/containers/buildah v1.26.9
 ## explicit; go 1.16
 github.com/containers/buildah
 github.com/containers/buildah/bind
@@ -113,8 +113,10 @@ github.com/containers/buildah/define
 github.com/containers/buildah/docker
 github.com/containers/buildah/imagebuildah
 github.com/containers/buildah/internal
+github.com/containers/buildah/internal/open
 github.com/containers/buildah/internal/parse
 github.com/containers/buildah/internal/util
+github.com/containers/buildah/internal/volumes
 github.com/containers/buildah/pkg/blobcache
 github.com/containers/buildah/pkg/chrootuser
 github.com/containers/buildah/pkg/overlay


### PR DESCRIPTION
Bumping `buildah` from 1.26.6 to 1.26.9 to fix [CVE-2024-9675](https://github.com/advisories/GHSA-586p-749j-fhwp)