### PR TITLE
pkg/build/builder/util/dockerfile.Write: reproduce heredocs

### DIFF
--- a/pkg/build/builder/util/dockerfile/dockerfile.go
+++ b/pkg/build/builder/util/dockerfile/dockerfile.go
@@ -62,6 +62,11 @@ func Write(node *parser.Node) []byte {
 				}
 				buf.Write([]byte(n.Value))
 			}
+			for _, heredoc := range node.Heredocs {
+				buf.Write([]byte(heredoc.Content))
+				buf.Write([]byte("\n"))
+				buf.Write([]byte(heredoc.Name))
+			}
 			buf.Write([]byte("\n"))
 			return buf.Bytes()
 		}

--- a/pkg/build/builder/util/dockerfile/dockerfile_test.go
+++ b/pkg/build/builder/util/dockerfile/dockerfile_test.go
@@ -94,6 +94,36 @@ WORKDIR /home
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/usr/bin/true"]
 `,
 		},
+		"Dockerfile with heredoc": {
+			in: `# This is a Dockerfile
+FROM scratch
+LABEL version=1.0
+# Here we start building a second image
+FROM busybox
+ENV PATH=/bin
+RUN <<EOF <<ALSO
+pwd
+EOF
+ls -1
+ALSO
+RUN <<EOF
+["ls","-1"]
+EOF
+`,
+			want: `FROM scratch
+LABEL version=1.0
+FROM busybox
+ENV PATH=/bin
+RUN <<EOF <<ALSO
+pwd
+EOF
+ls -1
+ALSO
+RUN <<EOF
+["ls","-1"]
+EOF
+`,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
When writing out the contents of a parsed Dockerfile, attempt to reproduce the heredocs that followed instructions.  Originally encountered by @jlebon while working on https://github.com/openshift/os/pull/1780.