### PR TITLE
OCPBUGS-56106: S2I build cpu limits observed by assemble are limited to 1 cpu

### DIFF
--- a/pkg/build/builder/util_linux.go
+++ b/pkg/build/builder/util_linux.go
@@ -127,10 +127,7 @@ func GetCGroupLimits() (*s2iapi.CGroupLimits, error) {
 	if memoryByteLimit > 92233720368547 {
 		memoryByteLimit = 92233720368547
 	}
-	// limit the number of microseconds to a million
-	if cpuQuota > 1000000 {
-		cpuQuota = 1000000
-	}
+
 	if cpuPeriod > 1000000 {
 		cpuPeriod = 1000000
 	}


### PR DESCRIPTION
Problem:
    When CPU limits are configured in the BuildConfig, applications running in the assemble script do not observe CPU values higher than 1 core. Any CPU limits set above 1 are rounded down to 1, causing builds to take longer and significantly reducing performance.

Solution:
    Removing the condition that caps the cpuQuota at 1,000,000 (i.e. 1 cpu limit). This hard limit was causing CPU limit configured in the BuildConfig to be rounded down to 1 core if they exceeded that threshold of 1,000,000.