### PR TITLE
CNF-23377: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/build/builder/cmd/dockercfg/cfg.go
+++ b/pkg/build/builder/cmd/dockercfg/cfg.go
@@ -2,7 +2,6 @@ package dockercfg
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -121,7 +120,7 @@ func readSpecificDockerConfigJSONFile(filePath string) error {
 	var contents []byte
 	var err error
 
-	if contents, err = ioutil.ReadFile(filePath); err != nil {
+	if contents, err = os.ReadFile(filePath); err != nil {
 		log.V(4).Infof("error reading file: %v", err)
 		return err
 	}

--- a/pkg/build/builder/cmd/dockercfg/cfg_test.go
+++ b/pkg/build/builder/cmd/dockercfg/cfg_test.go
@@ -1,7 +1,6 @@
 package dockercfg
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ func TestGetDockerAuth(t *testing.T) {
 
 	content := "{ \"auths\": { \"test-server-1.tld\":{\"auth\":\"Zm9vOmJhcgo=\",\"email\":\"test@email.test.com\"}}}"
 
-	tmpDirPath, err := ioutil.TempDir("", "test_foo_bar_")
+	tmpDirPath, err := os.MkdirTemp("", "test_foo_bar_")
 	if err != nil {
 		t.Fatalf("Creating tmp dir fail: %v", err)
 		return

--- a/pkg/build/builder/cmd/scmauth/cacert.go
+++ b/pkg/build/builder/cmd/scmauth/cacert.go
@@ -2,7 +2,7 @@ package scmauth
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
@@ -27,7 +27,7 @@ func (s CACert) Setup(baseDir string, context SCMAuthContext) (string, error) {
 	if !(s.SourceURL.Type == s2igit.URLTypeURL && s.SourceURL.URL.Scheme == "https" && s.SourceURL.URL.Opaque == "") {
 		return "", nil
 	}
-	gitconfig, err := ioutil.TempFile("", "ca.crt.")
+	gitconfig, err := os.CreateTemp("", "ca.crt.")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/build/builder/cmd/scmauth/password.go
+++ b/pkg/build/builder/cmd/scmauth/password.go
@@ -2,7 +2,6 @@ package scmauth
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -66,12 +65,12 @@ func (u UsernamePassword) Setup(baseDir string, context SCMAuthContext) (string,
 
 	// Write git config if needed
 	if gitconfigURL != nil {
-		gitcredentials, err := ioutil.TempFile("", "gitcredentials.")
+		gitcredentials, err := os.CreateTemp("", "gitcredentials.")
 		if err != nil {
 			return "", err
 		}
 		defer gitcredentials.Close()
-		gitconfig, err := ioutil.TempFile("", "gitcredentialscfg.")
+		gitconfig, err := os.CreateTemp("", "gitcredentialscfg.")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/build/builder/cmd/scmauth/scmauth_test.go
+++ b/pkg/build/builder/cmd/scmauth/scmauth_test.go
@@ -1,7 +1,6 @@
 package scmauth
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,12 +10,12 @@ import (
 )
 
 func secretDir(t *testing.T, files ...string) string {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
 	}
 	for _, f := range files {
-		err := ioutil.WriteFile(filepath.Join(dir, f), []byte("test"), 0600)
+		err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0600)
 		if err != nil {
 			t.Fatalf("error creating test file: %v", err)
 		}

--- a/pkg/build/builder/cmd/scmauth/scmauths.go
+++ b/pkg/build/builder/cmd/scmauth/scmauths.go
@@ -2,7 +2,6 @@ package scmauth
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -21,7 +20,7 @@ func GitAuths(sourceURL *s2igit.URL) SCMAuths {
 	return auths
 }
 
-func (a SCMAuths) present(files []os.FileInfo) SCMAuths {
+func (a SCMAuths) present(files []os.DirEntry) SCMAuths {
 	scmAuthsPresent := map[string]SCMAuth{}
 	for _, file := range files {
 		log.V(4).Infof("Finding auth for %q", file.Name())
@@ -53,7 +52,7 @@ func (a SCMAuths) doSetup(secretsDir string) (SCMAuthContext, error) {
 }
 
 func (a SCMAuths) Setup(secretsDir string) (env []string, overrideURL *url.URL, gitConfig string, err error) {
-	files, err := ioutil.ReadDir(secretsDir)
+	files, err := os.ReadDir(secretsDir)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/pkg/build/builder/cmd/scmauth/scmauths_test.go
+++ b/pkg/build/builder/cmd/scmauth/scmauths_test.go
@@ -1,7 +1,6 @@
 package scmauth
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -34,7 +33,7 @@ func scmAuths() SCMAuths {
 func TestPresent(t *testing.T) {
 	secretDir := secretDir(t, "one", "three")
 	defer os.RemoveAll(secretDir)
-	files, err := ioutil.ReadDir(secretDir)
+	files, err := os.ReadDir(secretDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/build/builder/cmd/scmauth/sshkey.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey.go
@@ -2,7 +2,7 @@ package scmauth
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -16,7 +16,7 @@ type SSHPrivateKey struct{}
 // SSH key while accessing private repository. Note that this does _not_ generate a .gitconfig
 // file or set the GIT_CONFIG environment variable.
 func (SSHPrivateKey) Setup(baseDir string, context SCMAuthContext) (string, error) {
-	script, err := ioutil.TempFile("", "gitssh")
+	script, err := os.CreateTemp("", "gitssh")
 	if err != nil {
 		return "", err
 	}
@@ -26,7 +26,7 @@ func (SSHPrivateKey) Setup(baseDir string, context SCMAuthContext) (string, erro
 	}
 	foundPrivateKey := false
 	foundKnownHosts := false
-	files, err := ioutil.ReadDir(baseDir)
+	files, err := os.ReadDir(baseDir)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/build/builder/cmd/scmauth/sshkey_test.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey_test.go
@@ -1,7 +1,6 @@
 package scmauth
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ func TestSSHPrivateKeySetup(t *testing.T) {
 	if !isSet {
 		t.Errorf("GIT_SSH is not set")
 	}
-	buf, err := ioutil.ReadFile(fileName)
+	buf, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Errorf("problem reading ssh file %s", err.Error())
 	}
@@ -55,7 +54,7 @@ func TestSSHPrivateKeyWithKnownHostsSetup(t *testing.T) {
 	if !isSet {
 		t.Errorf("GIT_SSH is not set")
 	}
-	buf, err := ioutil.ReadFile(fileName)
+	buf, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Errorf("problem reading ssh file %s", err.Error())
 	}

--- a/pkg/build/builder/cmd/scmauth/util.go
+++ b/pkg/build/builder/cmd/scmauth/util.go
@@ -2,7 +2,6 @@ package scmauth
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,13 +16,13 @@ var log = utillog.ToFile(os.Stderr, 2)
 // section to the provided path.
 // Returns the path to the git configuration file, and error if raised.
 func createGitConfig(includePath string, context SCMAuthContext) (string, error) {
-	tempDir, err := ioutil.TempDir("", "git")
+	tempDir, err := os.MkdirTemp("", "git")
 	if err != nil {
 		return "", err
 	}
 	gitconfig := filepath.Join(tempDir, ".gitconfig")
 	content := fmt.Sprintf("[include]\npath = %s\n", includePath)
-	if err := ioutil.WriteFile(gitconfig, []byte(content), 0600); err != nil {
+	if err := os.WriteFile(gitconfig, []byte(content), 0600); err != nil {
 		return "", err
 	}
 	// The GIT_CONFIG variable won't affect regular git operation
@@ -61,6 +60,6 @@ func ensureGitConfigIncludes(path string, context SCMAuthContext) (string, error
 
 	lines = append(lines, fmt.Sprintf("path = %s", path))
 	content := []byte(strings.Join(lines, "\n"))
-	err = ioutil.WriteFile(gitconfig, content, 0600)
+	err = os.WriteFile(gitconfig, content, 0600)
 	return gitconfig, err
 }

--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -369,7 +368,7 @@ func readSourceInfo() (*git.SourceInfo, error) {
 		return nil, nil
 	}
 
-	data, err := ioutil.ReadFile(sourceInfoPath)
+	data, err := os.ReadFile(sourceInfoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +388,7 @@ func readSourceInfo() (*git.SourceInfo, error) {
 func addBuildParameters(dir string, build *buildapiv1.Build, sourceInfo *git.SourceInfo) error {
 	dockerfilePath := getDockerfilePath(dir, build)
 
-	in, err := ioutil.ReadFile(dockerfilePath)
+	in, err := os.ReadFile(dockerfilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/builder/common_test.go
+++ b/pkg/build/builder/common_test.go
@@ -2,7 +2,6 @@ package builder
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -506,7 +505,7 @@ func Test_addBuildParameters(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			f, err := ioutil.TempFile("", "builder-dockertest")
+			f, err := os.CreateTemp("", "builder-dockertest")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -532,7 +531,7 @@ func Test_addBuildParameters(t *testing.T) {
 			build.Spec.Source.Images = test.build
 			sourceInfo := &git.SourceInfo{}
 			testErr := addBuildParameters(filepath.Dir(f.Name()), build, sourceInfo)
-			out, err := ioutil.ReadFile(f.Name())
+			out, err := os.ReadFile(f.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -658,7 +657,7 @@ func Test_findReferencedImages(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			f, err := ioutil.TempFile("", "builder-dockertest")
+			f, err := os.CreateTemp("", "builder-dockertest")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -191,7 +190,7 @@ func pullDaemonlessImage(sc types.SystemContext, store storage.Store, imageName 
 	// in case the node credentials facilitate the pulling of the image
 	mergedCreds := mergeNodeCredentials(dockerConfigCreds)
 
-	dstFile, err := ioutil.TempFile("", "config")
+	dstFile, err := os.CreateTemp("", "config")
 	if err != nil {
 		return fmt.Errorf("error creating tmp credentials file: %v", err)
 	}
@@ -407,7 +406,7 @@ func appendRHRepoMount(pathStart string, mountsMap *TransientMounts) error {
 
 	// Add a bind of repo file, to pass along anything that the runtime mounted from the node
 	log.V(0).Infof("Adding transient rw bind mount for %s", path)
-	tmpDir, err := ioutil.TempDir("/tmp", repoFile+"-copy")
+	tmpDir, err := os.MkdirTemp("/tmp", repoFile+"-copy")
 	if err != nil {
 		log.V(0).Infof("Falling back to the Red Hat yum repository configuration in the base image: failed to create tmpdir for %s secret: %v", repoFile, err)
 		return nil
@@ -445,7 +444,7 @@ func coreAppendSecretLinksToDirs(pathStart, pathEnd string, mountsMap *Transient
 
 	// Add a bind of dir secret, to pass along anything that the runtime mounted from the node
 	log.V(0).Infof("Adding transient rw bind mount for %s", path)
-	tmpDir, err := ioutil.TempDir("/tmp", pathEnd+"-copy")
+	tmpDir, err := os.MkdirTemp("/tmp", pathEnd+"-copy")
 	if err != nil {
 		log.V(0).Infof("Red Hat subscription content will not be available in this build: failed to create tmpdir for %s secrets: %v", pathEnd, err)
 		return nil

--- a/pkg/build/builder/daemonless_test.go
+++ b/pkg/build/builder/daemonless_test.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -429,7 +428,7 @@ func coreTestSubscriptionDirMounts(t *testing.T, path string, fn appendFunc) {
 		},
 	}
 	for _, tc := range cases {
-		tmpDir, err := ioutil.TempDir(os.TempDir(), tc.name)
+		tmpDir, err := os.MkdirTemp(os.TempDir(), tc.name)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -498,7 +497,7 @@ func coreTestSubscriptionDirMounts(t *testing.T, path string, fn appendFunc) {
 			splitMount := strings.Split(mounts[0], ":")
 			if len(splitMount) > 0 {
 				copyDir := splitMount[0]
-				files, err := ioutil.ReadDir(copyDir)
+				files, err := os.ReadDir(copyDir)
 				if err != nil {
 					t.Fatalf(err.Error())
 				}
@@ -573,7 +572,7 @@ func TestRHRepoMount(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tmpDir, err := ioutil.TempDir(os.TempDir(), tc.name)
+		tmpDir, err := os.MkdirTemp(os.TempDir(), tc.name)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -391,7 +390,7 @@ func TestDockerfilePath(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		buildDir, err := ioutil.TempDir("", "dockerfile-path")
+		buildDir, err := os.MkdirTemp("", "dockerfile-path")
 		if err != nil {
 			t.Errorf("failed to create tmpdir: %v", err)
 			continue
@@ -407,7 +406,7 @@ func TestDockerfilePath(t *testing.T) {
 			t.Errorf("failed to create directory %s: %v", filepath.Dir(absoluteDockerfilePath), err)
 			continue
 		}
-		if err = ioutil.WriteFile(absoluteDockerfilePath, []byte(from), os.FileMode(0644)); err != nil {
+		if err = os.WriteFile(absoluteDockerfilePath, []byte(from), os.FileMode(0644)); err != nil {
 			t.Errorf("failed to write dockerfile to %s: %v", absoluteDockerfilePath, err)
 			continue
 		}
@@ -465,7 +464,7 @@ func TestDockerfilePath(t *testing.T) {
 		}
 
 		// check that our Dockerfile has been modified
-		dockerfileData, err := ioutil.ReadFile(absoluteDockerfilePath)
+		dockerfileData, err := os.ReadFile(absoluteDockerfilePath)
 		if err != nil {
 			t.Errorf("failed to read dockerfile %s: %v", absoluteDockerfilePath, err)
 			continue
@@ -573,7 +572,7 @@ USER 1001`
 
 	client := buildfake.Clientset{}
 
-	buildDir, err := ioutil.TempDir("", "dockerfile-path")
+	buildDir, err := os.MkdirTemp("", "dockerfile-path")
 	if err != nil {
 		t.Errorf("failed to create tmpdir: %v", err)
 	}

--- a/pkg/build/builder/dockerutil_test.go
+++ b/pkg/build/builder/dockerutil_test.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"io/ioutil"
 	"math"
 	"os"
 	"reflect"
@@ -145,7 +144,7 @@ func TestReadMaxStringOrInt64(t *testing.T) {
 			expectedErr: true,
 		},
 	}
-	tmpDir, err := ioutil.TempDir(os.TempDir(), t.Name())
+	tmpDir, err := os.MkdirTemp(os.TempDir(), t.Name())
 	if err != nil {
 		t.Fatalf("error creating tmp dir: %s", err.Error())
 	}

--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,7 +86,7 @@ func GitClone(ctx context.Context, gitClient GitClient, gitSource *buildapiv1.Gi
 				log.V(0).Infof("error: Unable to serialized git source info: %v", err)
 				return sourceInfo, nil
 			}
-			err = ioutil.WriteFile(filepath.Join(buildWorkDirMount, "sourceinfo.json"), sourceInfoJson, 0644)
+			err = os.WriteFile(filepath.Join(buildWorkDirMount, "sourceinfo.json"), sourceInfoJson, 0644)
 			if err != nil {
 				log.V(0).Infof("error: Unable to serialized git source info: %v", err)
 				return sourceInfo, nil
@@ -126,7 +125,7 @@ func ManageDockerfile(dir string, build *buildapiv1.Build) error {
 		if len(build.Spec.Source.ContextDir) != 0 {
 			baseDir = filepath.Join(baseDir, build.Spec.Source.ContextDir)
 		}
-		if err := ioutil.WriteFile(filepath.Join(baseDir, "Dockerfile"), []byte(*dockerfileSource), 0660); err != nil {
+		if err := os.WriteFile(filepath.Join(baseDir, "Dockerfile"), []byte(*dockerfileSource), 0660); err != nil {
 			build.Status.Phase = buildapiv1.BuildPhaseFailed
 			build.Status.Reason = buildapiv1.StatusReasonManageDockerfileFailed
 			build.Status.Message = builderutil.StatusMessageManageDockerfileFailed

--- a/pkg/build/builder/source_test.go
+++ b/pkg/build/builder/source_test.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,13 +49,13 @@ type testGitRepo struct {
 
 func initializeTestGitRepo(name string) (*testGitRepo, error) {
 	repo := &testGitRepo{Name: name}
-	dir, err := ioutil.TempDir("", "test-"+repo.Name)
+	dir, err := os.MkdirTemp("", "test-"+repo.Name)
 	if err != nil {
 		return repo, err
 	}
 	repo.Path = dir
 	tmpfn := filepath.Join(dir, "initial-file")
-	if err := ioutil.WriteFile(tmpfn, []byte("test"), 0666); err != nil {
+	if err := os.WriteFile(tmpfn, []byte("test"), 0666); err != nil {
 		return repo, fmt.Errorf("unable to create temporary file")
 	}
 	repo.Files = append(repo.Files, tmpfn)
@@ -139,11 +138,11 @@ func (r *testGitRepo) cleanup() {
 }
 
 func (r *testGitRepo) addCommit() error {
-	f, err := ioutil.TempFile(r.Path, "")
+	f, err := os.CreateTemp(r.Path, "")
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(f.Name(), []byte("test"), 0666); err != nil {
+	if err := os.WriteFile(f.Name(), []byte("test"), 0666); err != nil {
 		return fmt.Errorf("unable to create temporary file %q", f.Name())
 	}
 	addCmd := exec.Command("git", "add", ".")
@@ -178,7 +177,7 @@ func TestUnqualifiedClone(t *testing.T) {
 	if err := repo.addCommit(); err != nil {
 		t.Errorf("unable to add commit: %v", err)
 	}
-	destDir, err := ioutil.TempDir("", "clone-dest-")
+	destDir, err := os.MkdirTemp("", "clone-dest-")
 	defer os.RemoveAll(destDir)
 	client := git.NewRepositoryWithEnv([]string{})
 	source := &buildapiv1.GitBuildSource{URI: "file://" + repo.Path}
@@ -219,7 +218,7 @@ func TestCloneFromRef(t *testing.T) {
 	if err := repo.addCommit(); err != nil {
 		t.Errorf("unable to add commit: %v", err)
 	}
-	destDir, err := ioutil.TempDir("", "commit-dest-")
+	destDir, err := os.MkdirTemp("", "commit-dest-")
 	defer os.RemoveAll(destDir)
 	client := git.NewRepositoryWithEnv([]string{})
 	firstCommitRef, err := repo.getRef(-1)
@@ -279,7 +278,7 @@ func TestCloneFromBranch(t *testing.T) {
 	if err := repo.addCommit(); err != nil {
 		t.Errorf("unable to add commit: %v", err)
 	}
-	destDir, err := ioutil.TempDir("", "branch-dest-")
+	destDir, err := os.MkdirTemp("", "branch-dest-")
 	defer os.RemoveAll(destDir)
 	client := git.NewRepositoryWithEnv([]string{})
 	source := &buildapiv1.GitBuildSource{
@@ -386,7 +385,7 @@ func TestCopyImageSourceFromFilesystem(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testDir, err := ioutil.TempDir("", "copy-src-from-fs")
+			testDir, err := os.MkdirTemp("", "copy-src-from-fs")
 			if err != nil {
 				t.Fatalf("failed to create test directory: %v", err)
 			}
@@ -431,7 +430,7 @@ func createTestFile(testDir string, filename string, content string) error {
 			return err
 		}
 	}
-	return ioutil.WriteFile(file, []byte(content), 0644)
+	return os.WriteFile(file, []byte(content), 0644)
 }
 
 func createTestSymlink(testDir string, linkname string, source string) error {
@@ -458,7 +457,7 @@ func verifyFile(filename string, expectedContent string, t *testing.T) {
 	case mode&os.ModeSymlink != 0:
 		t.Errorf("expected regular file for %s, got symlink", filename)
 	case mode.IsRegular():
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			t.Errorf("could not read %s: %v", filename, err)
 		}

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -372,7 +371,7 @@ func (s *S2IBuilder) Build() error {
 
 	startTime := metav1.Now()
 	if _, err := os.Stat(config.AsDockerfile); !os.IsNotExist(err) {
-		in, err := ioutil.ReadFile(config.AsDockerfile)
+		in, err := os.ReadFile(config.AsDockerfile)
 		if err != nil {
 			return err
 		}

--- a/pkg/build/builder/util_linux.go
+++ b/pkg/build/builder/util_linux.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,7 +89,7 @@ func GetCGroupLimits() (*s2iapi.CGroupLimits, error) {
 	for _, filename := range []string{memoryLimitFile, cpuQuotaFile, cpuPeriodFile, cpuSharesFile} {
 		if _, ok := fileContents[filename]; !ok {
 			var b []byte
-			b, err = ioutil.ReadFile(filename)
+			b, err = os.ReadFile(filename)
 			if err != nil {
 				goto returnError
 			}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration from `ioutil` to `os` package:**

_File and directory operations:_
* Replaced all instances of `ioutil.ReadFile`, `ioutil.WriteFile`, and `ioutil.ReadDir` with `os.ReadFile`, `os.WriteFile`, and `os.ReadDir` respectively throughout the codebase, including files like `cfg.go`, `scmauths.go`, `sshkey.go`, `common.go`, and their associated test files. [[1]](diffhunk://#diff-c03d7238ce9323054201f2662fa570f079de62c5b97c31cf91651e0ed493b097L124-R123) [[2]](diffhunk://#diff-573d20618e1962db193ef716a5cfbe5d5c516fa8232036528638fcc836e949c4L56-R55) [[3]](diffhunk://#diff-83f880527fdf6008de3a9e995c08d42ef019cf6dd2afd990958b496a0951dc40L29-R29) [[4]](diffhunk://#diff-c3e3fd9a5718fe56ca4fbd15758fd4fd839b73556d90a620d9c097c2c3cf4643L372-R371) [[5]](diffhunk://#diff-c3e3fd9a5718fe56ca4fbd15758fd4fd839b73556d90a620d9c097c2c3cf4643L392-R391) [[6]](diffhunk://#diff-7329384b2436b44070e937a4362ba7318ac489fa08c9e71c5bfa2850451c2aabL535-R534) [[7]](diffhunk://#diff-b61cfa8b9301f558a99e4be9f83c75364d2c475fd1e7e35ed518ffe5e56c3eefL501-R500) [[8]](diffhunk://#diff-37fe3c8bf69fff9e29834c2cb70f18e6fed1b604fc08de7b04e2fad0028d6704L34-R33) [[9]](diffhunk://#diff-37fe3c8bf69fff9e29834c2cb70f18e6fed1b604fc08de7b04e2fad0028d6704L58-R57)

* Updated all usages of `ioutil.TempFile` and `ioutil.TempDir` to `os.CreateTemp` and `os.MkdirTemp` respectively, ensuring temporary files and directories are created using the recommended APIs. [[1]](diffhunk://#diff-46b212ba531fc1d7ee6e1c6eab3edc1a8debe3cb57358323c3fb038290729c09L30-R30) [[2]](diffhunk://#diff-b6b134cdfe65ef8b9d52517f5139061795bcc242d84c2d4f6ae828d6b29e44acL69-R73) [[3]](diffhunk://#diff-83f880527fdf6008de3a9e995c08d42ef019cf6dd2afd990958b496a0951dc40L19-R19) [[4]](diffhunk://#diff-212c902aa5586cd3b3401e70e4679d8d4fd8a308c2ffa023c10a58c5c4850f2cL20-R25) [[5]](diffhunk://#diff-7329384b2436b44070e937a4362ba7318ac489fa08c9e71c5bfa2850451c2aabL509-R508) [[6]](diffhunk://#diff-7329384b2436b44070e937a4362ba7318ac489fa08c9e71c5bfa2850451c2aabL661-R660) [[7]](diffhunk://#diff-9a18a571061b068db5c93ccfb3b354c59d32cb835224bbee929350034fb7fb92L194-R193) [[8]](diffhunk://#diff-9a18a571061b068db5c93ccfb3b354c59d32cb835224bbee929350034fb7fb92L410-R409) [[9]](diffhunk://#diff-9a18a571061b068db5c93ccfb3b354c59d32cb835224bbee929350034fb7fb92L448-R447) [[10]](diffhunk://#diff-b61cfa8b9301f558a99e4be9f83c75364d2c475fd1e7e35ed518ffe5e56c3eefL432-R431) [[11]](diffhunk://#diff-b61cfa8b9301f558a99e4be9f83c75364d2c475fd1e7e35ed518ffe5e56c3eefL576-R575) [[12]](diffhunk://#diff-26fd37e95ba61abe910b3a45e165fabdeb081658439a549f298c53a42a0e0b62L19-R18) [[13]](diffhunk://#diff-f24cf02b4f12cc51b5a9377bcc4ec62b3aedbcac7abaa50ad1b7d5fad8019e8aL14-R18) [[14]](diffhunk://#diff-3885f5466c42dd0f0d057eb79cc0573f66d57b1109b080a002ec81dd08b4b5c4L37-R36)

_Imports and cleanup:_
* Removed all `ioutil` imports and replaced them with appropriate `os` imports in all affected files. [[1]](diffhunk://#diff-c03d7238ce9323054201f2662fa570f079de62c5b97c31cf91651e0ed493b097L5) [[2]](diffhunk://#diff-26fd37e95ba61abe910b3a45e165fabdeb081658439a549f298c53a42a0e0b62L4) [[3]](diffhunk://#diff-46b212ba531fc1d7ee6e1c6eab3edc1a8debe3cb57358323c3fb038290729c09L5-R5) [[4]](diffhunk://#diff-b6b134cdfe65ef8b9d52517f5139061795bcc242d84c2d4f6ae828d6b29e44acL5) [[5]](diffhunk://#diff-f24cf02b4f12cc51b5a9377bcc4ec62b3aedbcac7abaa50ad1b7d5fad8019e8aL4) [[6]](diffhunk://#diff-573d20618e1962db193ef716a5cfbe5d5c516fa8232036528638fcc836e949c4L5) [[7]](diffhunk://#diff-3885f5466c42dd0f0d057eb79cc0573f66d57b1109b080a002ec81dd08b4b5c4L4) [[8]](diffhunk://#diff-83f880527fdf6008de3a9e995c08d42ef019cf6dd2afd990958b496a0951dc40L5-R5) [[9]](diffhunk://#diff-37fe3c8bf69fff9e29834c2cb70f18e6fed1b604fc08de7b04e2fad0028d6704L4) [[10]](diffhunk://#diff-212c902aa5586cd3b3401e70e4679d8d4fd8a308c2ffa023c10a58c5c4850f2cL5) [[11]](diffhunk://#diff-c3e3fd9a5718fe56ca4fbd15758fd4fd839b73556d90a620d9c097c2c3cf4643L9) [[12]](diffhunk://#diff-7329384b2436b44070e937a4362ba7318ac489fa08c9e71c5bfa2850451c2aabL5) [[13]](diffhunk://#diff-9a18a571061b068db5c93ccfb3b354c59d32cb835224bbee929350034fb7fb92L11) [[14]](diffhunk://#diff-b61cfa8b9301f558a99e4be9f83c75364d2c475fd1e7e35ed518ffe5e56c3eefL4) [[15]](diffhunk://#diff-7c9b4e6b77e3b6c877c62015f5bec816fe42b5818edc34b69ae57381303ecd9bL8)

These changes ensure the project is compatible with newer Go versions and avoids deprecated functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced deprecated file and temporary-file helpers with modern Go stdlib equivalents across the builder and test suites. Changes update file read/write and temp dir/file operations, removing the old dependency. No functional, behavioral, or public API changes; existing error handling and test assertions preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->