### PR TITLE
OKD-322: Update Dockerfile to work on CentOS/RHEL 10

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -4,9 +4,16 @@ COPY . .
 RUN hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
-RUN INSTALL_PKGS=" \
+RUN . /etc/os-release && \
+    CONTAINER_RUNTIME=runc && \
+    # CentOS/RHEL 10 does not have runc as a package, so replace with crun
+    # Remove when base image is upgraded to RHEL 10
+    if [ "${PLATFORM_ID}" = "platform:el10" ]; then \
+        CONTAINER_RUNTIME=crun; \
+    fi && \
+    INSTALL_PKGS=" \
       bind-utils bsdtar findutils fuse-overlayfs git git-lfs hostname lsof \
-      netavark procps-ng runc socat tar util-linux wget which \
+      netavark procps-ng ${CONTAINER_RUNTIME} socat tar util-linux wget which \
       " && \
     yum install -y --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all


### PR DESCRIPTION
Starting with version OKD version 4.22, we are attempting to use CentOS 10 base images. The builder fails to build on CentOS 10 since runc isn't a available package on CentOS 10. For more context [this](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=openshift-enterprise-builder-container-v4.22.0-202602121448.p2.g711f2e6.assembly.test.scos9&record_id=18819d28-4aa9-a271-e410-b6c77cdf103c&group=okd-4.22) is the build log (Red Hat VPN required to view the build log)