### PR TITLE
OCPBUGS-67026: Bump golang.org/x/crypto/ssh/agent to v0.43.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -839,7 +839,7 @@ go.starlark.net/resolve
 go.starlark.net/starlark
 go.starlark.net/starlarkstruct
 go.starlark.net/syntax
-# golang.org/x/crypto v0.14.0 => golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
+# golang.org/x/crypto v0.43.0 => golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
 ## explicit; go 1.11
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5


### PR DESCRIPTION
This PR is part of an automated process.

The commands used to generate this PR were:

```
go get golang.org/x/crypto/ssh/agent@v0.43.0 toolchain@none
go mod tidy
go mod vendor
```

A member of the Red Hat Openshift Sustaining Team will review the PR and take appropriate action.