### PR TITLE
NO-JIRA: Bump Go builder image from 1.23 to 1.24 for OpenShift 4.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.19

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/builder
 COPY . .
 RUN hack/build.sh

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/builder
 COPY . .
 RUN hack/build.sh


### PR DESCRIPTION
bumping base golang from 1.23 to 1.24